### PR TITLE
Update bring_your_own_model_tutorial.ipynb

### DIFF
--- a/python/wherobots-ai/gpu/bring_your_own_model_tutorial.ipynb
+++ b/python/wherobots-ai/gpu/bring_your_own_model_tutorial.ipynb
@@ -209,7 +209,7 @@
     "from sedona.spark import SedonaContext\n",
     "from pyspark.sql.functions import expr\n",
     "\n",
-    "config = SedonaContext.builder().appName('segmentation-batch-inference')\\\\\n",
+    "config = SedonaContext.builder().appName('segmentation-batch-inference')\\\\n",
     "    .getOrCreate()\n",
     "\n",
     "sedona = SedonaContext.create(config)"


### PR DESCRIPTION
The extra slash (`\`) was causing an error when I tried to run the cell.