### PR TITLE
[EWT-1330] Specify the number of output files rather than the size of output files in CREATE SPATIAL INDEX

### DIFF
--- a/python/havasu/havasu-iceberg-geometry-etl.ipynb
+++ b/python/havasu/havasu-iceberg-geometry-etl.ipynb
@@ -690,7 +690,7 @@
     }
    ],
    "source": [
-    "sedona.sql(\"CREATE SPATIAL INDEX FOR wherobots.test_db.taxi USING hilbert(pickup, 16) OPTIONS map('target-file-size-bytes', '1000000')\").show()"
+    "sedona.sql(\"CREATE SPATIAL INDEX FOR wherobots.test_db.taxi USING hilbert(pickup, 16) OPTIONS map('target-file-count', '30')\").show()"
    ]
   },
   {


### PR DESCRIPTION
This is based on features introduced by https://github.com/wherobots/havasu-iceberg/pull/73