### PR TITLE
clean up dead code and uneeded configs in map matching example

### DIFF
--- a/python/wherobots-ai/mapmatching_example.ipynb
+++ b/python/wherobots-ai/mapmatching_example.ipynb
@@ -19,27 +19,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import local libraries\n",
-    "import matplotlib.pyplot as plt\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "import os\n",
-    "import time\n",
     "import json\n",
-    "\n",
-    "# Import GeoPandas\n",
-    "import geopandas as gpd\n",
-    "\n",
-    "# Import Shapely\n",
     "from shapely.geometry import LineString\n",
-    "\n",
-    "# Import PySpark\n",
-    "from pyspark.sql import SparkSession\n",
-    "from pyspark.sql.types import StructField, StructType, StringType, IntegerType, DoubleType, FloatType\n",
     "from pyspark.sql.window import Window\n",
     "from pyspark.sql.functions import col, expr, udf, collect_list, struct, row_number, lit\n",
-    "\n",
-    "# Import Apache Sedona\n",
     "from sedona.spark import *"
    ]
   },
@@ -58,14 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    sedona\n",
-    "except NameError:\n",
-    "    config = SedonaContext.builder() .\\\n",
-    "    config(\"fs.s3a.bucket.wherobots-examples.aws.credentials.provider\",\"org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider\") .\\\n",
-    "    config(\"spark.hadoop.fs.s3a.bucket.wherobots-examples.aws.credentials.provider\",\"org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider\") .\\\n",
-    "    getOrCreate()\n",
-    "    sedona = SedonaContext.create(config)"
+    "config = SedonaContext.builder().getOrCreate()\n",
+    "sedona = SedonaContext.create(config)"
    ]
   },
   {


### PR DESCRIPTION
I tested this by running in staging.

Config is already in teh k8s recipe: https://github.com/search?q=org%3Awherobots+spark.hadoop.fs.s3a.bucket.wherobots-examples.aws.credentials.provider+language%3AYAML&type=code&l=YAML