### PR TITLE
decrease batch size to account for new .pt2 archive format and correct text on nnumber of inferences to match sql

### DIFF
--- a/python/wherobots-ai/gpu/segmentation.ipynb
+++ b/python/wherobots-ai/gpu/segmentation.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "To run predictions we will specify the model we wish to use. Some models are pre-loaded and made available in Wherobots Cloud. We can also load our own models. Predictions can be run with the Raster Inference SQL function [`RS_Segment`](https://docs.wherobots.com/latest/api/wherobots-inference/pythondoc/inference/sql_functions/) or the Python API.\n",
     "\n",
-    "Here we generate 300 raster predictions using `RS_Segment`."
+    "Here we generate 400 raster predictions using `RS_Segment`."
    ]
   },
   {
@@ -256,7 +256,7 @@
    "source": [
     "from wherobots.inference.engine.register import create_semantic_segmentation_udfs\n",
     "from pyspark.sql.functions import col\n",
-    "rs_segment =  create_semantic_segmentation_udfs(batch_size = 10, sedona=sedona)\n",
+    "rs_segment =  create_semantic_segmentation_udfs(batch_size = 9, sedona=sedona)\n",
     "df = df_raster_input.withColumn(\"segment_result\", rs_segment(model_id, col(\"outdb_raster\"))).select(\n",
     "                               \"outdb_raster\",\n",
     "                               col(\"segment_result.confidence_array\").alias(\"confidence_array\"),\n",
@@ -292,7 +292,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
.pt2 archives in pytorch 2.6.0 consume more peak gpu memory than in pytorch 2.3.0, so adjusting the batch size lower int he python example.  This is a necessary fix once 1.6.0 is released so that this cell doesn't OOM