### PR TITLE
Add RasterFlow deforestation and forest growth notebook

### DIFF
--- a/Analyzing_Data/RasterFlow_CHM-Deforestation-Change.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM-Deforestation-Change.ipynb
@@ -166,17 +166,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5bba03d-d6a6-4707-9e12-c5c58bc2463d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_outputs_2018 = \"s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fprl5j2g5smrw1/2e8b161dbdc0.zarr\"\n",
-    "model_outputs_2021 = \"s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fx1r1lfjam6wzi/3b59aa9a61dc.zarr\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "f1778a67",
    "metadata": {},
    "outputs": [],

--- a/Analyzing_Data/RasterFlow_CHM-Deforestation-Change.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM-Deforestation-Change.ipynb
@@ -1,0 +1,386 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fa47acec",
+   "metadata": {},
+   "source": "<img src=\"assets/img/chm-banner.jpg\">\n\n# Detecting deforestation and forest growth with RasterFlow\n\nThis notebook will guide you through detecting deforestation and forest growth by comparing canopy height estimates across time, using Wherobots RasterFlow and the [Meta and World Resources Institute's Canopy Height prediction model (Meta CHM v1)](https://github.com/facebookresearch/HighResCanopyHeight/)<sup>1</sup>. This is an open source regression model that can predict the height of the tree canopy from high resolution imagery. The result of the model is a raster where each pixel is the estimated tree canopy height in meters.\n\nBy running this model on imagery from two different time periods and computing the difference, we can identify areas of significant canopy loss (deforestation) and canopy growth. We can then extract deforestation pockets as vector polygons for further analysis."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b9a9b70-8490-4193-87de-75232a26892a",
+   "metadata": {},
+   "source": [
+    "## Running inference on high resolution imagery\n",
+    "\n",
+    "The Meta CHM v1 model was trained on 50cm resolution data, so we will select imagery with a similar resolution for our testing.\n",
+    "\n",
+    "The National Agriculture Imagery Program (NAIP) provides aerial imagery for the United States, capturing high-resolution images during the agricultural growing seasons. The NAIP dataset contains a mixture of resolutions (30cm, 60cm and 1m).  See [this map](https://esri.maps.arcgis.com/apps/mapviewer/index.html?webmap=6cc0dcb225de4cb8aaa23c6a9cb59db8) for more details.  We will use 60cm imagery to test this model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74a65529",
+   "metadata": {},
+   "source": "## Selecting an Area of Interest (AOI)\nWe will choose an Area of Interest (AOI) for our analysis. \n\nThe area around Nashua, NH has a combination of urban settings, parks and forests so we will try out the model there. From the map, we see that 60cm imagery for New Hampshire was captured in both 2018 and 2021, so we will use these two time periods to detect change."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "53c7f20d-bf38-472a-9aaf-83218a4c8fea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:52:38.399540Z",
+     "iopub.status.busy": "2026-03-09T19:52:38.399318Z",
+     "iopub.status.idle": "2026-03-09T19:52:48.399482Z",
+     "shell.execute_reply": "2026-03-09T19:52:48.398805Z",
+     "shell.execute_reply.started": "2026-03-09T19:52:38.399524Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "66eb68cb73994db9b2b6c6959870e4f8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import wkls\n",
+    "import geopandas as gpd\n",
+    "import os\n",
+    "\n",
+    "# Generate a geometry for Nashua, NH using WKLS (https://github.com/wherobots/wkls)\n",
+    "gdf = gpd.read_file(wkls.us.nh.nashua.geojson())\n",
+    "\n",
+    "# Save the geometry to a parquet file in the user's S3 path\n",
+    "aoi_path = os.getenv(\"USER_S3_PATH\") + \"nashua.parquet\"\n",
+    "gdf.to_parquet(aoi_path)\n",
+    "\n",
+    "# we'll make variables for the bounds of our aoi for use after running inference to visualize results\n",
+    "min_lon, min_lat, max_lon, max_lat = gdf.total_bounds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4f2b94c",
+   "metadata": {},
+   "source": [
+    "## Initializing the RasterFlow client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bbc4534b-5ca6-448f-8215-c4a97c410452",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:24:05.112724Z",
+     "iopub.status.busy": "2026-03-09T19:24:05.112547Z",
+     "iopub.status.idle": "2026-03-09T19:24:06.983911Z",
+     "shell.execute_reply": "2026-03-09T19:24:06.983034Z",
+     "shell.execute_reply.started": "2026-03-09T19:24:05.112706Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "from rasterflow_remote import RasterflowClient\n",
+    "\n",
+    "from rasterflow_remote.data_models import (\n",
+    "    ModelRecipes\n",
+    ")\n",
+    "\n",
+    "rf_client = RasterflowClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e414dee",
+   "metadata": {},
+   "source": "## Running the model on two time periods\n\nRasterFlow has pre-defined workflows to simplify orchestration of the processing steps for model inference.  These steps include:\n* Ingesting imagery for the specified Area of Interest (AOI)\n* Generating a seamless image from multiple image tiles (a mosaic) \n* Running inference with the selected model\n\nThe output is a Zarr store of the model outputs.\n\nWe will run the CHM model twice — once for 2021 imagery and once for 2018 imagery — so we can compare canopy height between the two periods.\n\nNote: Each model run will take approximately 20 minutes to complete."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f979011b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:24:06.990531Z",
+     "iopub.status.busy": "2026-03-09T19:24:06.990409Z",
+     "iopub.status.idle": "2026-03-09T19:24:16.416482Z",
+     "shell.execute_reply": "2026-03-09T19:24:16.415968Z",
+     "shell.execute_reply.started": "2026-03-09T19:24:06.990517Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🌎 [8s] SUCCEEDED | ID: ad6m6kdmmnp75vhztl7n\n",
+      "s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fx1r1lfjam6wzi/3b59aa9a61dc.zarr\n"
+     ]
+    }
+   ],
+   "source": [
+    "model_outputs_2021 = rf_client.build_and_predict_mosaic_recipe(\n",
+    "    # Path to our AOI in GeoParquet or GeoJSON format\n",
+    "    aoi = aoi_path,\n",
+    "\n",
+    "    # Date range for imagery to be used by the model\n",
+    "    start = datetime(2021, 1, 1),\n",
+    "    end = datetime(2022, 1, 1),\n",
+    "\n",
+    "    # Coordinate Reference System EPSG code for the output mosaic   \n",
+    "    crs_epsg = 3857,\n",
+    "\n",
+    "    # The model recipe to be used for inference (CHM in this case)\n",
+    "    model_recipe = ModelRecipes.META_CHM_V1\n",
+    ")\n",
+    "\n",
+    "print(model_outputs_2021)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1c59aa2a-cd6e-4e8d-8559-913a647c76ce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:24:16.417167Z",
+     "iopub.status.busy": "2026-03-09T19:24:16.417041Z",
+     "iopub.status.idle": "2026-03-09T19:24:25.053794Z",
+     "shell.execute_reply": "2026-03-09T19:24:25.053186Z",
+     "shell.execute_reply.started": "2026-03-09T19:24:16.417153Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🌎 [8s] SUCCEEDED | ID: ap5nwqgfcqr5tfgbqjs6\n",
+      "s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fprl5j2g5smrw1/2e8b161dbdc0.zarr\n"
+     ]
+    }
+   ],
+   "source": [
+    "model_outputs_2018 = rf_client.build_and_predict_mosaic_recipe(\n",
+    "    # Path to our AOI in GeoParquet or GeoJSON format\n",
+    "    aoi = aoi_path,\n",
+    "\n",
+    "    # Date range for imagery to be used by the model\n",
+    "    start = datetime(2018, 1, 1),\n",
+    "    end = datetime(2019, 1, 1),\n",
+    "\n",
+    "    # Coordinate Reference System EPSG code for the output mosaic   \n",
+    "    crs_epsg = 3857,\n",
+    "\n",
+    "    # The model recipe to be used for inference (CHM in this case)\n",
+    "    model_recipe = ModelRecipes.META_CHM_V1\n",
+    ")\n",
+    "\n",
+    "print(model_outputs_2018)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b6fc2ab",
+   "metadata": {},
+   "source": "## Visualize the canopy height for each time period\nWe will use hvplot and datashader to visualize the canopy height model outputs for 2021 and 2018. This lets us inspect the raw model predictions before computing the change between the two periods."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d5bba03d-d6a6-4707-9e12-c5c58bc2463d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:52:22.761823Z",
+     "iopub.status.busy": "2026-03-09T19:52:22.761612Z",
+     "iopub.status.idle": "2026-03-09T19:52:22.765879Z",
+     "shell.execute_reply": "2026-03-09T19:52:22.765284Z",
+     "shell.execute_reply.started": "2026-03-09T19:52:22.761806Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_outputs_2018 = \"s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fprl5j2g5smrw1/2e8b161dbdc0.zarr\"\n",
+    "model_outputs_2021 = \"s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fx1r1lfjam6wzi/3b59aa9a61dc.zarr\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1778a67",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:52:52.895940Z",
+     "iopub.status.busy": "2026-03-09T19:52:52.895463Z",
+     "iopub.status.idle": "2026-03-09T19:53:14.483936Z",
+     "shell.execute_reply": "2026-03-09T19:53:14.483203Z",
+     "shell.execute_reply.started": "2026-03-09T19:52:52.895921Z"
+    }
+   },
+   "outputs": [],
+   "source": "# Import libraries for visualization and coordinate transformation\nimport hvplot.xarray\nimport xarray as xr\nimport s3fs \nimport zarr\nfrom pyproj import Transformer\nfrom holoviews.element.tiles import EsriImagery \n\n# Open the Zarr store\nfs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\nzstore = zarr.storage.FsspecStore(fs, path=model_outputs_2021[5:])\nds = xr.open_zarr(zstore)\n\n# Create a transformer to convert from lat/lon to meters\ntransformer = Transformer.from_crs(\"EPSG:4326\", \"EPSG:3857\", always_xy=True)\n\n# Transform bounding box coordinates from lat/lon to meters\n(min_x, max_x), (min_y, max_y) = transformer.transform(\n    [min_lon, max_lon], \n    [min_lat, max_lat]\n)\n\n# Select the height variable and slice the dataset to the bounding box\n# y=slice(max_y, min_y) handles the standard \"North-to-South\" image orientation\nds_subset = ds.sel(band=\"height\",\n    x=slice(min_x, max_x), \n    y=slice(max_y, min_y) \n)\n\n# Select the first time step and extract the variables array\narr_subset_2021 = ds_subset.isel(time=0)[\"variables\"].compute()\n\n# Create a base map layer using Esri satellite imagery\nbase_map = EsriImagery()\n\n# Create an overlay layer from the model outputs with hvplot\noutput_layer = arr_subset_2021.hvplot(\n    x = \"x\",\n    y = \"y\",\n    geo = True,           # Enable geographic plotting\n    dynamic = True,       # Enable dynamic rendering for interactivity\n    rasterize = True,     # Use datashader for efficient rendering of large datasets\n    cmap = \"viridis\",     # Color map for visualization\n    aspect = \"equal\",     # Maintain equal aspect ratio\n    title = \"Canopy Height 2021\" \n).opts(\n    width = 600, \n    height = 600,\n    alpha = 0.7           # Set transparency to see the base map underneath\n)\n\n# Combine the base map and output layer\nfinal_plot = base_map * output_layer\nfinal_plot"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf799fd0-c26f-4d11-874a-efbde02732ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:53:14.488995Z",
+     "iopub.status.busy": "2026-03-09T19:53:14.488873Z",
+     "iopub.status.idle": "2026-03-09T19:53:33.461025Z",
+     "shell.execute_reply": "2026-03-09T19:53:33.460204Z",
+     "shell.execute_reply.started": "2026-03-09T19:53:14.488982Z"
+    }
+   },
+   "outputs": [],
+   "source": "# Open the 2018 Zarr store\nzstore_2018 = zarr.storage.FsspecStore(fs, path=model_outputs_2018[5:])\nds_2018 = xr.open_zarr(zstore_2018)\n\n# Select the height variable and slice the dataset to the bounding box\nds_subset_2018 = ds_2018.sel(band=\"height\",\n    x=slice(min_x, max_x), \n    y=slice(max_y, min_y) \n)\n\n# Select the first time step and extract the variables array\narr_subset_2018 = ds_subset_2018.isel(time=0)[\"variables\"].compute()\n\n# Create a base map layer using Esri satellite imagery\nbase_map = EsriImagery()\n\n# Create an overlay layer from the model outputs with hvplot\noutput_layer = arr_subset_2018.hvplot(\n    x = \"x\",\n    y = \"y\",\n    geo = True,           # Enable geographic plotting\n    dynamic = True,       # Enable dynamic rendering for interactivity\n    rasterize = True,     # Use datashader for efficient rendering of large datasets\n    cmap = \"viridis\",     # Color map for visualization\n    aspect = \"equal\",     # Maintain equal aspect ratio\n    title = \"Canopy Height 2018\" \n).opts(\n    width = 600, \n    height = 600,\n    alpha = 0.7           # Set transparency to see the base map underneath\n)\n\n# Combine the base map and output layer\nfinal_plot = base_map * output_layer\nfinal_plot"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eugbe6gppf",
+   "source": "## Computing canopy height change\n\nNow we subtract the 2018 canopy height from the 2021 canopy height. The resulting raster contains per-pixel height change in meters:\n* **Negative values** indicate canopy loss (deforestation, clearing, or die-off)\n* **Positive values** indicate canopy growth\n\nWe will visualize each direction separately to highlight areas of forest loss and forest growth.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2ff6d5b5-314f-4a74-9420-970fea0e86ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:55:11.860829Z",
+     "iopub.status.busy": "2026-03-09T19:55:11.860609Z",
+     "iopub.status.idle": "2026-03-09T19:55:12.278070Z",
+     "shell.execute_reply": "2026-03-09T19:55:12.277061Z",
+     "shell.execute_reply.started": "2026-03-09T19:55:11.860810Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "canopy_change = (arr_subset_2021 - arr_subset_2018).compute()\n",
+    "canopy_change.name = \"height_change_m\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fd50bfa-6db1-4f05-a6ce-63b54b432bd7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:55:14.340488Z",
+     "iopub.status.busy": "2026-03-09T19:55:14.340272Z",
+     "iopub.status.idle": "2026-03-09T19:55:15.713708Z",
+     "shell.execute_reply": "2026-03-09T19:55:15.713088Z",
+     "shell.execute_reply.started": "2026-03-09T19:55:14.340473Z"
+    }
+   },
+   "outputs": [],
+   "source": "# Visualize canopy height loss (deforestation): clip positive values to zero\nbase_map_change = EsriImagery()\n\nchange_layer = canopy_change.clip(None, 0).hvplot(\n        x = \"x\",\n        y = \"y\",\n        geo = True,           # Enable geographic plotting\n        dynamic = True,       # Enable dynamic rendering for interactivity\n        rasterize = True,     # Use datashader for efficient rendering of large datasets\n        cmap = \"hot_r\",       # High-contrast heatmap: cool=no change, hot=large loss\n        aspect = \"equal\",     # Maintain equal aspect ratio\n        title = \"Canopy Height Loss 2018 → 2021 (meters)\"\n).opts(\n        width = 600,\n        height = 600,\n        alpha = 0.75,         # Set transparency to see the basemap underneath\n        colorbar = True,\n        clabel = \"Height Change (m)\"\n)\n\n# Combine the base map and change layer\nchange_plot = base_map_change * change_layer\nchange_plot"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f28d4ba5-677b-4597-a63c-d4341cb1d0eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T19:55:21.114898Z",
+     "iopub.status.busy": "2026-03-09T19:55:21.114701Z",
+     "iopub.status.idle": "2026-03-09T19:55:22.492319Z",
+     "shell.execute_reply": "2026-03-09T19:55:22.491631Z",
+     "shell.execute_reply.started": "2026-03-09T19:55:21.114882Z"
+    }
+   },
+   "outputs": [],
+   "source": "# Visualize canopy height growth: clip negative values to zero\nbase_map_growth = EsriImagery()\n\ngrowth_layer = canopy_change.clip(0, None).hvplot(\n        x = \"x\",\n        y = \"y\",\n        geo = True,           # Enable geographic plotting\n        dynamic = True,       # Enable dynamic rendering for interactivity\n        rasterize = True,     # Use datashader for efficient rendering of large datasets\n        cmap = \"Greens\",      # Green color map for forest growth\n        aspect = \"equal\",     # Maintain equal aspect ratio\n        title = \"Canopy Height Growth 2018 → 2021 (meters)\"\n).opts(\n        width = 600,\n        height = 600,\n        alpha = 0.75,         # Set transparency to see the basemap underneath\n        colorbar = True,\n        clabel = \"Height Change (m)\"\n)\n\n# Combine the base map and growth layer\ngrowth_plot = base_map_growth * growth_layer\ngrowth_plot"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ujo9bfsq20n",
+   "source": "## Extracting deforestation pockets as polygons\n\nTo make the deforestation results actionable, we can convert areas of significant canopy loss into vector polygons. We apply a threshold (e.g., −20 meters) to identify pixels with substantial height loss, then use `rasterio.features.shapes` to vectorize the resulting binary mask into polygon geometries.\n\nThe resulting GeoDataFrame contains individual deforestation pockets that can be used for further spatial analysis, reporting, or integration with other geospatial workflows.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e424f81-bb47-4547-90b7-9bc56e890c5b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T20:07:59.151793Z",
+     "iopub.status.busy": "2026-03-09T20:07:59.151591Z",
+     "iopub.status.idle": "2026-03-09T20:08:08.946435Z",
+     "shell.execute_reply": "2026-03-09T20:08:08.945843Z",
+     "shell.execute_reply.started": "2026-03-09T20:07:59.151778Z"
+    }
+   },
+   "outputs": [],
+   "source": "import numpy as np\nimport rasterio\nimport geopandas as gpd\nfrom shapely.geometry import shape\n\n# Threshold in meters: pixels with canopy loss exceeding this value are flagged\nthreshold = -20\n\n# Create a binary deforestation mask\nmask = (canopy_change < threshold).astype(np.uint8)\n\n# Convert raster mask to vector polygons\npolygons = list(rasterio.features.shapes(mask.values, transform=mask.rio.transform(), connectivity=8))\ngdf = gpd.GeoDataFrame(\n    [{\"geometry\": shape(geom), \"value\": int(val)} for geom, val in polygons],\n    crs=mask.rio.crs\n).query(\"value == 1\").reset_index(drop=True)\n\n# Dissolve adjacent polygons into contiguous deforestation pockets\ngdf = (\n    gdf\n    .dissolve()                          # merge all into one MultiPolygon\n    .explode(index_parts=False)          # split back into individual groups\n    .reset_index(drop=True)\n)\n\nprint(f\"Deforestation pockets detected: {len(gdf)}\")\ngdf.head()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8x06myr44a",
+   "source": "## Visualize deforestation pockets\n\nFinally, we overlay the extracted deforestation polygons on a satellite base map to see where significant canopy loss occurred between 2018 and 2021.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22428ed5-6b6b-4ba4-9add-483bdd5c5f6e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-09T20:10:49.041955Z",
+     "iopub.status.busy": "2026-03-09T20:10:49.041752Z",
+     "iopub.status.idle": "2026-03-09T20:11:07.422283Z",
+     "shell.execute_reply": "2026-03-09T20:11:07.420849Z",
+     "shell.execute_reply.started": "2026-03-09T20:10:49.041941Z"
+    }
+   },
+   "outputs": [],
+   "source": "import hvplot.pandas\n\n# Reproject to EPSG:4326 for tile alignment\nbase_map_deforestation = EsriImagery()\n\ndeforestation_layer = gdf.to_crs(\"EPSG:4326\").hvplot(\n    geo=True,\n    color=\"red\",\n    alpha=0.6,\n    line_color=\"orangered\",\n    line_width=0.5,\n    width=700,\n    height=700,\n    title=\"Deforestation Pockets 2018 → 2021 (change < −20 m)\",\n    legend=False\n)\n\n# Combine base map and deforestation layer\ndeforestation_plot = base_map_deforestation * deforestation_layer\ndeforestation_plot"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44e79110",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "\n",
+    "1. **Tolan, J., Yang, H.-I., Nosarzewski, B., Couairon, G., Vo, H. V., Brandt, J., Spore, J., Majumdar, S., Haziza, D., Vamaraju, J., et al. (2024).** Very high resolution canopy height maps from RGB imagery using self-supervised vision transformer and convolutional decoder trained on aerial lidar. *Remote Sensing of Environment*, 300, 113888."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Analyzing_Data/RasterFlow_CHM-Deforestation-Change.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM-Deforestation-Change.ipynb
@@ -4,7 +4,15 @@
    "cell_type": "markdown",
    "id": "fa47acec",
    "metadata": {},
-   "source": "<img src=\"assets/img/chm-banner.jpg\">\n\n# Detecting deforestation and forest growth with RasterFlow\n\nThis notebook will guide you through detecting deforestation and forest growth by comparing canopy height estimates across time, using Wherobots RasterFlow and the [Meta and World Resources Institute's Canopy Height prediction model (Meta CHM v1)](https://github.com/facebookresearch/HighResCanopyHeight/)<sup>1</sup>. This is an open source regression model that can predict the height of the tree canopy from high resolution imagery. The result of the model is a raster where each pixel is the estimated tree canopy height in meters.\n\nBy running this model on imagery from two different time periods and computing the difference, we can identify areas of significant canopy loss (deforestation) and canopy growth. We can then extract deforestation pockets as vector polygons for further analysis."
+   "source": [
+    "<img src=\"assets/img/chm-banner.jpg\">\n",
+    "\n",
+    "# Detecting deforestation and forest growth with RasterFlow\n",
+    "\n",
+    "This notebook will guide you through detecting deforestation and forest growth by comparing canopy height estimates across time, using Wherobots RasterFlow and the [Meta and World Resources Institute's Canopy Height prediction model (Meta CHM v1)](https://github.com/facebookresearch/HighResCanopyHeight/)<sup>1</sup>. This is an open source regression model that can predict the height of the tree canopy from high resolution imagery. The result of the model is a raster where each pixel is the estimated tree canopy height in meters.\n",
+    "\n",
+    "By running this model on imagery from two different time periods and computing the difference, we can identify areas of significant canopy loss (deforestation) and canopy growth. We can then extract deforestation pockets as vector polygons for further analysis."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -22,37 +30,19 @@
    "cell_type": "markdown",
    "id": "74a65529",
    "metadata": {},
-   "source": "## Selecting an Area of Interest (AOI)\nWe will choose an Area of Interest (AOI) for our analysis. \n\nThe area around Nashua, NH has a combination of urban settings, parks and forests so we will try out the model there. From the map, we see that 60cm imagery for New Hampshire was captured in both 2018 and 2021, so we will use these two time periods to detect change."
+   "source": [
+    "## Selecting an Area of Interest (AOI)\n",
+    "We will choose an Area of Interest (AOI) for our analysis. \n",
+    "\n",
+    "The area around Nashua, NH has a combination of urban settings, parks and forests so we will try out the model there. From the map, we see that 60cm imagery for New Hampshire was captured in both 2018 and 2021, so we will use these two time periods to detect change."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "53c7f20d-bf38-472a-9aaf-83218a4c8fea",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:52:38.399540Z",
-     "iopub.status.busy": "2026-03-09T19:52:38.399318Z",
-     "iopub.status.idle": "2026-03-09T19:52:48.399482Z",
-     "shell.execute_reply": "2026-03-09T19:52:48.398805Z",
-     "shell.execute_reply.started": "2026-03-09T19:52:38.399524Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66eb68cb73994db9b2b6c6959870e4f8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "FloatProgress(value=0.0, layout=Layout(width='auto'), style=ProgressStyle(bar_color='black'))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import wkls\n",
     "import geopandas as gpd\n",
@@ -79,17 +69,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "bbc4534b-5ca6-448f-8215-c4a97c410452",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:24:05.112724Z",
-     "iopub.status.busy": "2026-03-09T19:24:05.112547Z",
-     "iopub.status.idle": "2026-03-09T19:24:06.983911Z",
-     "shell.execute_reply": "2026-03-09T19:24:06.983034Z",
-     "shell.execute_reply.started": "2026-03-09T19:24:05.112706Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
@@ -107,31 +89,27 @@
    "cell_type": "markdown",
    "id": "2e414dee",
    "metadata": {},
-   "source": "## Running the model on two time periods\n\nRasterFlow has pre-defined workflows to simplify orchestration of the processing steps for model inference.  These steps include:\n* Ingesting imagery for the specified Area of Interest (AOI)\n* Generating a seamless image from multiple image tiles (a mosaic) \n* Running inference with the selected model\n\nThe output is a Zarr store of the model outputs.\n\nWe will run the CHM model twice — once for 2021 imagery and once for 2018 imagery — so we can compare canopy height between the two periods.\n\nNote: Each model run will take approximately 20 minutes to complete."
+   "source": [
+    "## Running the model on two time periods\n",
+    "\n",
+    "RasterFlow has pre-defined workflows to simplify orchestration of the processing steps for model inference.  These steps include:\n",
+    "* Ingesting imagery for the specified Area of Interest (AOI)\n",
+    "* Generating a seamless image from multiple image tiles (a mosaic) \n",
+    "* Running inference with the selected model\n",
+    "\n",
+    "The output is a Zarr store of the model outputs.\n",
+    "\n",
+    "We will run the CHM model twice — once for 2021 imagery and once for 2018 imagery — so we can compare canopy height between the two periods.\n",
+    "\n",
+    "Note: Each model run will take approximately 20 minutes to complete."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f979011b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:24:06.990531Z",
-     "iopub.status.busy": "2026-03-09T19:24:06.990409Z",
-     "iopub.status.idle": "2026-03-09T19:24:16.416482Z",
-     "shell.execute_reply": "2026-03-09T19:24:16.415968Z",
-     "shell.execute_reply.started": "2026-03-09T19:24:06.990517Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🌎 [8s] SUCCEEDED | ID: ad6m6kdmmnp75vhztl7n\n",
-      "s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fx1r1lfjam6wzi/3b59aa9a61dc.zarr\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "model_outputs_2021 = rf_client.build_and_predict_mosaic_recipe(\n",
     "    # Path to our AOI in GeoParquet or GeoJSON format\n",
@@ -153,27 +131,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "1c59aa2a-cd6e-4e8d-8559-913a647c76ce",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:24:16.417167Z",
-     "iopub.status.busy": "2026-03-09T19:24:16.417041Z",
-     "iopub.status.idle": "2026-03-09T19:24:25.053794Z",
-     "shell.execute_reply": "2026-03-09T19:24:25.053186Z",
-     "shell.execute_reply.started": "2026-03-09T19:24:16.417153Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🌎 [8s] SUCCEEDED | ID: ap5nwqgfcqr5tfgbqjs6\n",
-      "s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fprl5j2g5smrw1/2e8b161dbdc0.zarr\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "model_outputs_2018 = rf_client.build_and_predict_mosaic_recipe(\n",
     "    # Path to our AOI in GeoParquet or GeoJSON format\n",
@@ -197,21 +158,16 @@
    "cell_type": "markdown",
    "id": "6b6fc2ab",
    "metadata": {},
-   "source": "## Visualize the canopy height for each time period\nWe will use hvplot and datashader to visualize the canopy height model outputs for 2021 and 2018. This lets us inspect the raw model predictions before computing the change between the two periods."
+   "source": [
+    "## Visualize the canopy height for each time period\n",
+    "We will use hvplot and datashader to visualize the canopy height model outputs for 2021 and 2018. This lets us inspect the raw model predictions before computing the change between the two periods."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d5bba03d-d6a6-4707-9e12-c5c58bc2463d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:52:22.761823Z",
-     "iopub.status.busy": "2026-03-09T19:52:22.761612Z",
-     "iopub.status.idle": "2026-03-09T19:52:22.765879Z",
-     "shell.execute_reply": "2026-03-09T19:52:22.765284Z",
-     "shell.execute_reply.started": "2026-03-09T19:52:22.761806Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model_outputs_2018 = \"s3://wbts-temp-user-data-aws-us-west-2-prod/dfqlwcrxlk/rasterflow/rasterflow/production/fprl5j2g5smrw1/2e8b161dbdc0.zarr\"\n",
@@ -222,53 +178,128 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1778a67",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:52:52.895940Z",
-     "iopub.status.busy": "2026-03-09T19:52:52.895463Z",
-     "iopub.status.idle": "2026-03-09T19:53:14.483936Z",
-     "shell.execute_reply": "2026-03-09T19:53:14.483203Z",
-     "shell.execute_reply.started": "2026-03-09T19:52:52.895921Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
-   "source": "# Import libraries for visualization and coordinate transformation\nimport hvplot.xarray\nimport xarray as xr\nimport s3fs \nimport zarr\nfrom pyproj import Transformer\nfrom holoviews.element.tiles import EsriImagery \n\n# Open the Zarr store\nfs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\nzstore = zarr.storage.FsspecStore(fs, path=model_outputs_2021[5:])\nds = xr.open_zarr(zstore)\n\n# Create a transformer to convert from lat/lon to meters\ntransformer = Transformer.from_crs(\"EPSG:4326\", \"EPSG:3857\", always_xy=True)\n\n# Transform bounding box coordinates from lat/lon to meters\n(min_x, max_x), (min_y, max_y) = transformer.transform(\n    [min_lon, max_lon], \n    [min_lat, max_lat]\n)\n\n# Select the height variable and slice the dataset to the bounding box\n# y=slice(max_y, min_y) handles the standard \"North-to-South\" image orientation\nds_subset = ds.sel(band=\"height\",\n    x=slice(min_x, max_x), \n    y=slice(max_y, min_y) \n)\n\n# Select the first time step and extract the variables array\narr_subset_2021 = ds_subset.isel(time=0)[\"variables\"].compute()\n\n# Create a base map layer using Esri satellite imagery\nbase_map = EsriImagery()\n\n# Create an overlay layer from the model outputs with hvplot\noutput_layer = arr_subset_2021.hvplot(\n    x = \"x\",\n    y = \"y\",\n    geo = True,           # Enable geographic plotting\n    dynamic = True,       # Enable dynamic rendering for interactivity\n    rasterize = True,     # Use datashader for efficient rendering of large datasets\n    cmap = \"viridis\",     # Color map for visualization\n    aspect = \"equal\",     # Maintain equal aspect ratio\n    title = \"Canopy Height 2021\" \n).opts(\n    width = 600, \n    height = 600,\n    alpha = 0.7           # Set transparency to see the base map underneath\n)\n\n# Combine the base map and output layer\nfinal_plot = base_map * output_layer\nfinal_plot"
+   "source": [
+    "# Import libraries for visualization and coordinate transformation\n",
+    "import hvplot.xarray\n",
+    "import xarray as xr\n",
+    "import s3fs \n",
+    "import zarr\n",
+    "from pyproj import Transformer\n",
+    "from holoviews.element.tiles import EsriImagery \n",
+    "\n",
+    "# Open the Zarr store\n",
+    "fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "zstore = zarr.storage.FsspecStore(fs, path=model_outputs_2021[5:])\n",
+    "ds = xr.open_zarr(zstore)\n",
+    "\n",
+    "# Create a transformer to convert from lat/lon to meters\n",
+    "transformer = Transformer.from_crs(\"EPSG:4326\", \"EPSG:3857\", always_xy=True)\n",
+    "\n",
+    "# Transform bounding box coordinates from lat/lon to meters\n",
+    "(min_x, max_x), (min_y, max_y) = transformer.transform(\n",
+    "    [min_lon, max_lon], \n",
+    "    [min_lat, max_lat]\n",
+    ")\n",
+    "\n",
+    "# Select the height variable and slice the dataset to the bounding box\n",
+    "# y=slice(max_y, min_y) handles the standard \"North-to-South\" image orientation\n",
+    "ds_subset = ds.sel(band=\"height\",\n",
+    "    x=slice(min_x, max_x), \n",
+    "    y=slice(max_y, min_y) \n",
+    ")\n",
+    "\n",
+    "# Select the first time step and extract the variables array\n",
+    "arr_subset_2021 = ds_subset.isel(time=0)[\"variables\"].compute()\n",
+    "\n",
+    "# Create a base map layer using Esri satellite imagery\n",
+    "base_map = EsriImagery()\n",
+    "\n",
+    "# Create an overlay layer from the model outputs with hvplot\n",
+    "output_layer = arr_subset_2021.hvplot(\n",
+    "    x = \"x\",\n",
+    "    y = \"y\",\n",
+    "    geo = True,           # Enable geographic plotting\n",
+    "    dynamic = True,       # Enable dynamic rendering for interactivity\n",
+    "    rasterize = True,     # Use datashader for efficient rendering of large datasets\n",
+    "    cmap = \"viridis\",     # Color map for visualization\n",
+    "    aspect = \"equal\",     # Maintain equal aspect ratio\n",
+    "    title = \"Canopy Height 2021\" \n",
+    ").opts(\n",
+    "    width = 600, \n",
+    "    height = 600,\n",
+    "    alpha = 0.7           # Set transparency to see the base map underneath\n",
+    ")\n",
+    "\n",
+    "# Combine the base map and output layer\n",
+    "final_plot = base_map * output_layer\n",
+    "final_plot"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "bf799fd0-c26f-4d11-874a-efbde02732ab",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:53:14.488995Z",
-     "iopub.status.busy": "2026-03-09T19:53:14.488873Z",
-     "iopub.status.idle": "2026-03-09T19:53:33.461025Z",
-     "shell.execute_reply": "2026-03-09T19:53:33.460204Z",
-     "shell.execute_reply.started": "2026-03-09T19:53:14.488982Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
-   "source": "# Open the 2018 Zarr store\nzstore_2018 = zarr.storage.FsspecStore(fs, path=model_outputs_2018[5:])\nds_2018 = xr.open_zarr(zstore_2018)\n\n# Select the height variable and slice the dataset to the bounding box\nds_subset_2018 = ds_2018.sel(band=\"height\",\n    x=slice(min_x, max_x), \n    y=slice(max_y, min_y) \n)\n\n# Select the first time step and extract the variables array\narr_subset_2018 = ds_subset_2018.isel(time=0)[\"variables\"].compute()\n\n# Create a base map layer using Esri satellite imagery\nbase_map = EsriImagery()\n\n# Create an overlay layer from the model outputs with hvplot\noutput_layer = arr_subset_2018.hvplot(\n    x = \"x\",\n    y = \"y\",\n    geo = True,           # Enable geographic plotting\n    dynamic = True,       # Enable dynamic rendering for interactivity\n    rasterize = True,     # Use datashader for efficient rendering of large datasets\n    cmap = \"viridis\",     # Color map for visualization\n    aspect = \"equal\",     # Maintain equal aspect ratio\n    title = \"Canopy Height 2018\" \n).opts(\n    width = 600, \n    height = 600,\n    alpha = 0.7           # Set transparency to see the base map underneath\n)\n\n# Combine the base map and output layer\nfinal_plot = base_map * output_layer\nfinal_plot"
+   "source": [
+    "# Open the 2018 Zarr store\n",
+    "zstore_2018 = zarr.storage.FsspecStore(fs, path=model_outputs_2018[5:])\n",
+    "ds_2018 = xr.open_zarr(zstore_2018)\n",
+    "\n",
+    "# Select the height variable and slice the dataset to the bounding box\n",
+    "ds_subset_2018 = ds_2018.sel(band=\"height\",\n",
+    "    x=slice(min_x, max_x), \n",
+    "    y=slice(max_y, min_y) \n",
+    ")\n",
+    "\n",
+    "# Select the first time step and extract the variables array\n",
+    "arr_subset_2018 = ds_subset_2018.isel(time=0)[\"variables\"].compute()\n",
+    "\n",
+    "# Create a base map layer using Esri satellite imagery\n",
+    "base_map = EsriImagery()\n",
+    "\n",
+    "# Create an overlay layer from the model outputs with hvplot\n",
+    "output_layer = arr_subset_2018.hvplot(\n",
+    "    x = \"x\",\n",
+    "    y = \"y\",\n",
+    "    geo = True,           # Enable geographic plotting\n",
+    "    dynamic = True,       # Enable dynamic rendering for interactivity\n",
+    "    rasterize = True,     # Use datashader for efficient rendering of large datasets\n",
+    "    cmap = \"viridis\",     # Color map for visualization\n",
+    "    aspect = \"equal\",     # Maintain equal aspect ratio\n",
+    "    title = \"Canopy Height 2018\" \n",
+    ").opts(\n",
+    "    width = 600, \n",
+    "    height = 600,\n",
+    "    alpha = 0.7           # Set transparency to see the base map underneath\n",
+    ")\n",
+    "\n",
+    "# Combine the base map and output layer\n",
+    "final_plot = base_map * output_layer\n",
+    "final_plot"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "eugbe6gppf",
-   "source": "## Computing canopy height change\n\nNow we subtract the 2018 canopy height from the 2021 canopy height. The resulting raster contains per-pixel height change in meters:\n* **Negative values** indicate canopy loss (deforestation, clearing, or die-off)\n* **Positive values** indicate canopy growth\n\nWe will visualize each direction separately to highlight areas of forest loss and forest growth.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Computing canopy height change\n",
+    "\n",
+    "Now we subtract the 2018 canopy height from the 2021 canopy height. The resulting raster contains per-pixel height change in meters:\n",
+    "* **Negative values** indicate canopy loss (deforestation, clearing, or die-off)\n",
+    "* **Positive values** indicate canopy growth\n",
+    "\n",
+    "We will visualize each direction separately to highlight areas of forest loss and forest growth."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "2ff6d5b5-314f-4a74-9420-970fea0e86ef",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:55:11.860829Z",
-     "iopub.status.busy": "2026-03-09T19:55:11.860609Z",
-     "iopub.status.idle": "2026-03-09T19:55:12.278070Z",
-     "shell.execute_reply": "2026-03-09T19:55:12.277061Z",
-     "shell.execute_reply.started": "2026-03-09T19:55:11.860810Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "canopy_change = (arr_subset_2021 - arr_subset_2018).compute()\n",
@@ -279,77 +310,153 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0fd50bfa-6db1-4f05-a6ce-63b54b432bd7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:55:14.340488Z",
-     "iopub.status.busy": "2026-03-09T19:55:14.340272Z",
-     "iopub.status.idle": "2026-03-09T19:55:15.713708Z",
-     "shell.execute_reply": "2026-03-09T19:55:15.713088Z",
-     "shell.execute_reply.started": "2026-03-09T19:55:14.340473Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
-   "source": "# Visualize canopy height loss (deforestation): clip positive values to zero\nbase_map_change = EsriImagery()\n\nchange_layer = canopy_change.clip(None, 0).hvplot(\n        x = \"x\",\n        y = \"y\",\n        geo = True,           # Enable geographic plotting\n        dynamic = True,       # Enable dynamic rendering for interactivity\n        rasterize = True,     # Use datashader for efficient rendering of large datasets\n        cmap = \"hot_r\",       # High-contrast heatmap: cool=no change, hot=large loss\n        aspect = \"equal\",     # Maintain equal aspect ratio\n        title = \"Canopy Height Loss 2018 → 2021 (meters)\"\n).opts(\n        width = 600,\n        height = 600,\n        alpha = 0.75,         # Set transparency to see the basemap underneath\n        colorbar = True,\n        clabel = \"Height Change (m)\"\n)\n\n# Combine the base map and change layer\nchange_plot = base_map_change * change_layer\nchange_plot"
+   "source": [
+    "# Visualize canopy height loss (deforestation): clip positive values to zero\n",
+    "base_map_change = EsriImagery()\n",
+    "\n",
+    "change_layer = canopy_change.clip(None, 0).hvplot(\n",
+    "        x = \"x\",\n",
+    "        y = \"y\",\n",
+    "        geo = True,           # Enable geographic plotting\n",
+    "        dynamic = True,       # Enable dynamic rendering for interactivity\n",
+    "        rasterize = True,     # Use datashader for efficient rendering of large datasets\n",
+    "        cmap = \"hot_r\",       # High-contrast heatmap: cool=no change, hot=large loss\n",
+    "        aspect = \"equal\",     # Maintain equal aspect ratio\n",
+    "        title = \"Canopy Height Loss 2018 → 2021 (meters)\"\n",
+    ").opts(\n",
+    "        width = 600,\n",
+    "        height = 600,\n",
+    "        alpha = 0.75,         # Set transparency to see the basemap underneath\n",
+    "        colorbar = True,\n",
+    "        clabel = \"Height Change (m)\"\n",
+    ")\n",
+    "\n",
+    "# Combine the base map and change layer\n",
+    "change_plot = base_map_change * change_layer\n",
+    "change_plot"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "f28d4ba5-677b-4597-a63c-d4341cb1d0eb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T19:55:21.114898Z",
-     "iopub.status.busy": "2026-03-09T19:55:21.114701Z",
-     "iopub.status.idle": "2026-03-09T19:55:22.492319Z",
-     "shell.execute_reply": "2026-03-09T19:55:22.491631Z",
-     "shell.execute_reply.started": "2026-03-09T19:55:21.114882Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
-   "source": "# Visualize canopy height growth: clip negative values to zero\nbase_map_growth = EsriImagery()\n\ngrowth_layer = canopy_change.clip(0, None).hvplot(\n        x = \"x\",\n        y = \"y\",\n        geo = True,           # Enable geographic plotting\n        dynamic = True,       # Enable dynamic rendering for interactivity\n        rasterize = True,     # Use datashader for efficient rendering of large datasets\n        cmap = \"Greens\",      # Green color map for forest growth\n        aspect = \"equal\",     # Maintain equal aspect ratio\n        title = \"Canopy Height Growth 2018 → 2021 (meters)\"\n).opts(\n        width = 600,\n        height = 600,\n        alpha = 0.75,         # Set transparency to see the basemap underneath\n        colorbar = True,\n        clabel = \"Height Change (m)\"\n)\n\n# Combine the base map and growth layer\ngrowth_plot = base_map_growth * growth_layer\ngrowth_plot"
+   "source": [
+    "# Visualize canopy height growth: clip negative values to zero\n",
+    "base_map_growth = EsriImagery()\n",
+    "\n",
+    "growth_layer = canopy_change.clip(0, None).hvplot(\n",
+    "        x = \"x\",\n",
+    "        y = \"y\",\n",
+    "        geo = True,           # Enable geographic plotting\n",
+    "        dynamic = True,       # Enable dynamic rendering for interactivity\n",
+    "        rasterize = True,     # Use datashader for efficient rendering of large datasets\n",
+    "        cmap = \"Greens\",      # Green color map for forest growth\n",
+    "        aspect = \"equal\",     # Maintain equal aspect ratio\n",
+    "        title = \"Canopy Height Growth 2018 → 2021 (meters)\"\n",
+    ").opts(\n",
+    "        width = 600,\n",
+    "        height = 600,\n",
+    "        alpha = 0.75,         # Set transparency to see the basemap underneath\n",
+    "        colorbar = True,\n",
+    "        clabel = \"Height Change (m)\"\n",
+    ")\n",
+    "\n",
+    "# Combine the base map and growth layer\n",
+    "growth_plot = base_map_growth * growth_layer\n",
+    "growth_plot"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ujo9bfsq20n",
-   "source": "## Extracting deforestation pockets as polygons\n\nTo make the deforestation results actionable, we can convert areas of significant canopy loss into vector polygons. We apply a threshold (e.g., −20 meters) to identify pixels with substantial height loss, then use `rasterio.features.shapes` to vectorize the resulting binary mask into polygon geometries.\n\nThe resulting GeoDataFrame contains individual deforestation pockets that can be used for further spatial analysis, reporting, or integration with other geospatial workflows.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Extracting deforestation pockets as polygons\n",
+    "\n",
+    "To make the deforestation results actionable, we can convert areas of significant canopy loss into vector polygons. We apply a threshold (e.g., −20 meters) to identify pixels with substantial height loss, then use `rasterio.features.shapes` to vectorize the resulting binary mask into polygon geometries.\n",
+    "\n",
+    "The resulting GeoDataFrame contains individual deforestation pockets that can be used for further spatial analysis, reporting, or integration with other geospatial workflows."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "2e424f81-bb47-4547-90b7-9bc56e890c5b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T20:07:59.151793Z",
-     "iopub.status.busy": "2026-03-09T20:07:59.151591Z",
-     "iopub.status.idle": "2026-03-09T20:08:08.946435Z",
-     "shell.execute_reply": "2026-03-09T20:08:08.945843Z",
-     "shell.execute_reply.started": "2026-03-09T20:07:59.151778Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
-   "source": "import numpy as np\nimport rasterio\nimport geopandas as gpd\nfrom shapely.geometry import shape\n\n# Threshold in meters: pixels with canopy loss exceeding this value are flagged\nthreshold = -20\n\n# Create a binary deforestation mask\nmask = (canopy_change < threshold).astype(np.uint8)\n\n# Convert raster mask to vector polygons\npolygons = list(rasterio.features.shapes(mask.values, transform=mask.rio.transform(), connectivity=8))\ngdf = gpd.GeoDataFrame(\n    [{\"geometry\": shape(geom), \"value\": int(val)} for geom, val in polygons],\n    crs=mask.rio.crs\n).query(\"value == 1\").reset_index(drop=True)\n\n# Dissolve adjacent polygons into contiguous deforestation pockets\ngdf = (\n    gdf\n    .dissolve()                          # merge all into one MultiPolygon\n    .explode(index_parts=False)          # split back into individual groups\n    .reset_index(drop=True)\n)\n\nprint(f\"Deforestation pockets detected: {len(gdf)}\")\ngdf.head()"
+   "source": [
+    "import numpy as np\n",
+    "import rasterio\n",
+    "import geopandas as gpd\n",
+    "from shapely.geometry import shape\n",
+    "\n",
+    "# Threshold in meters: pixels with canopy loss exceeding this value are flagged\n",
+    "threshold = -20\n",
+    "\n",
+    "# Create a binary deforestation mask\n",
+    "mask = (canopy_change < threshold).astype(np.uint8)\n",
+    "\n",
+    "# Convert raster mask to vector polygons\n",
+    "polygons = list(rasterio.features.shapes(mask.values, transform=mask.rio.transform(), connectivity=8))\n",
+    "gdf = gpd.GeoDataFrame(\n",
+    "    [{\"geometry\": shape(geom), \"value\": int(val)} for geom, val in polygons],\n",
+    "    crs=mask.rio.crs\n",
+    ").query(\"value == 1\").reset_index(drop=True)\n",
+    "\n",
+    "# Dissolve adjacent polygons into contiguous deforestation pockets\n",
+    "gdf = (\n",
+    "    gdf\n",
+    "    .dissolve()                          # merge all into one MultiPolygon\n",
+    "    .explode(index_parts=False)          # split back into individual groups\n",
+    "    .reset_index(drop=True)\n",
+    ")\n",
+    "\n",
+    "print(f\"Deforestation pockets detected: {len(gdf)}\")\n",
+    "gdf.head()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "a8x06myr44a",
-   "source": "## Visualize deforestation pockets\n\nFinally, we overlay the extracted deforestation polygons on a satellite base map to see where significant canopy loss occurred between 2018 and 2021.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Visualize deforestation pockets\n",
+    "\n",
+    "Finally, we overlay the extracted deforestation polygons on a satellite base map to see where significant canopy loss occurred between 2018 and 2021."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "22428ed5-6b6b-4ba4-9add-483bdd5c5f6e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-09T20:10:49.041955Z",
-     "iopub.status.busy": "2026-03-09T20:10:49.041752Z",
-     "iopub.status.idle": "2026-03-09T20:11:07.422283Z",
-     "shell.execute_reply": "2026-03-09T20:11:07.420849Z",
-     "shell.execute_reply.started": "2026-03-09T20:10:49.041941Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
-   "source": "import hvplot.pandas\n\n# Reproject to EPSG:4326 for tile alignment\nbase_map_deforestation = EsriImagery()\n\ndeforestation_layer = gdf.to_crs(\"EPSG:4326\").hvplot(\n    geo=True,\n    color=\"red\",\n    alpha=0.6,\n    line_color=\"orangered\",\n    line_width=0.5,\n    width=700,\n    height=700,\n    title=\"Deforestation Pockets 2018 → 2021 (change < −20 m)\",\n    legend=False\n)\n\n# Combine base map and deforestation layer\ndeforestation_plot = base_map_deforestation * deforestation_layer\ndeforestation_plot"
+   "source": [
+    "import hvplot.pandas\n",
+    "\n",
+    "# Reproject to EPSG:4326 for tile alignment\n",
+    "base_map_deforestation = EsriImagery()\n",
+    "\n",
+    "deforestation_layer = gdf.to_crs(\"EPSG:4326\").hvplot(\n",
+    "    geo=True,\n",
+    "    color=\"red\",\n",
+    "    alpha=0.6,\n",
+    "    line_color=\"orangered\",\n",
+    "    line_width=0.5,\n",
+    "    width=700,\n",
+    "    height=700,\n",
+    "    title=\"Deforestation Pockets 2018 → 2021 (change < −20 m)\",\n",
+    "    legend=False\n",
+    ")\n",
+    "\n",
+    "# Combine base map and deforestation layer\n",
+    "deforestation_plot = base_map_deforestation * deforestation_layer\n",
+    "deforestation_plot"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -377,8 +484,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.15"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines, pre-commit s
 |   |-- PMTiles-railroad.ipynb
 |   |-- RasterFlow_Bring_Your_Own_Model.ipynb
 |   |-- RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+|   |-- RasterFlow_CHM-Deforestation-Change.ipynb
 |   |-- RasterFlow_CHM.ipynb
 |   |-- RasterFlow_ChangeDetection.ipynb
 |   |-- RasterFlow_Chesapeake.ipynb


### PR DESCRIPTION
## Summary
- Adds new notebook `RasterFlow_CHM-Deforestation-Change.ipynb` demonstrating multi-temporal canopy height change detection
- Runs Meta CHM v1 model on 2018 and 2021 NAIP imagery to compute per-pixel height change
- Visualizes canopy loss (deforestation) and canopy growth separately with distinct colormaps
- Extracts deforestation pockets as vector polygons via thresholding + vectorization

## Test plan
- [ ] Verify notebook renders correctly in Wherobots Cloud
- [ ] Run all cells end-to-end and confirm outputs match expected visualizations
- [ ] Check narrative markdown flows logically between code cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)