### PR TITLE
fix: align rasterflow notebooks with actor enum rename

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -577,11 +577,11 @@
    "outputs": [],
    "source": [
     "from dataclasses import asdict\n",
-    "from rasterflow_remote.data_models import InferenceConfig, InferenceActorEnum, MergeModeEnum, ResamplingMethod\n",
+    "from rasterflow_remote.data_models import InferenceConfig, MergeModeEnum, MosaicToMosaicActorEnum, ResamplingMethod\n",
     "\n",
     "custom_inference_config = InferenceConfig(\n",
     "    model_path = s3_model_path,\n",
-    "    actor = InferenceActorEnum.REGRESSION_PYTORCH,\n",
+    "    actor = MosaicToMosaicActorEnum.REGRESSION_PYTORCH,\n",
     "    patch_size = 224,\n",
     "    clip_size = 28,\n",
     "    device = \"cuda\",\n",

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -549,7 +549,7 @@
    "source": [
     "# # Uncomment to run road detection on the NAIP mosaic\n",
     "# \n",
-    "# from rasterflow_remote import InferenceActorEnum\n",
+    "# from rasterflow_remote import MosaicToMosaicActorEnum\n",
     "# from rasterflow_remote.data_models import MergeModeEnum\n",
     "# \n",
     "# # ChesapeakeRSC model - direct URL (no HuggingFace auth required)\n",
@@ -563,7 +563,7 @@
     "#     device=\"cuda\",\n",
     "#     features=[\"r\", \"g\", \"b\", \"ir\"],  # Must match the bands in our mosaic\n",
     "#     labels=[\"background\", \"road\"],\n",
-    "#     actor=InferenceActorEnum.SEMANTIC_SEGMENTATION_PYTORCH,\n",
+    "#     actor=MosaicToMosaicActorEnum.SEMANTIC_SEGMENTATION_PYTORCH,\n",
     "#     max_batch_size=256,\n",
     "#     merge_mode=MergeModeEnum.WEIGHTED_AVERAGE,\n",
     "# )\n",

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -44,7 +44,7 @@
     "        return logits      # (N, Classes, H, W)\n",
     "```\n",
     "\n",
-    "We'll use a particular **Actor** to run change detection inference using Rasterflow: `InferenceActorEnum.SEMANTIC_SEGMENTATION_CHANGE_DETECTION_PYTORCH`."
+    "We'll use a particular **Actor** to run change detection inference using Rasterflow: `MosaicToMosaicActorEnum.SEMANTIC_SEGMENTATION_CHANGE_DETECTION_PYTORCH`."
    ]
   },
   {
@@ -97,7 +97,7 @@
    "source": [
     "from datetime import datetime\n",
     "\n",
-    "from rasterflow_remote import RasterflowClient, DatasetEnum, InferenceActorEnum\n",
+    "from rasterflow_remote import RasterflowClient, DatasetEnum, MosaicToMosaicActorEnum\n",
     "\n",
     "from rasterflow_remote.data_models import (\n",
     "    VectorizeMethodEnum,\n",
@@ -250,7 +250,7 @@
     "        \"field\",\n",
     "        \"field_boundaries\",\n",
     "    ],\n",
-    "    actor=InferenceActorEnum.SEMANTIC_SEGMENTATION_CHANGE_DETECTION_PYTORCH,\n",
+    "    actor=MosaicToMosaicActorEnum.SEMANTIC_SEGMENTATION_CHANGE_DETECTION_PYTORCH,\n",
     "    max_batch_size=128,\n",
     "    merge_mode=MergeModeEnum.WEIGHTED_AVERAGE,\n",
     "    xy_block_multiplier=1\n",


### PR DESCRIPTION
Update the RasterFlow notebooks to use `MosaicToMosaicActorEnum` after the `InferenceActorEnum` removal in `rasterflow-remote`.

This keeps the bring-your-own-model, change detection, and NAIP examples aligned with the rasterflow_remote API.