### PR TITLE
docs: use first_row_mosaic to get mosaic store URI

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -612,9 +612,8 @@
     "        **asdict(custom_inference_config)\n",
     ")\n",
     "\n",
-    "predict_index_gdf = gpd.read_parquet(predict_mosaic_output.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "predict_store = predict_index_gdf.iloc[0][\"location\"]"
+    "predict_store = predict_mosaic_output.first_row_mosaic"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -454,9 +454,8 @@
     "        resampling = ResamplingMethod.NEAREST,\n",
     "        nodata= 0.0,\n",
     ")\n",
-    "mosaic_index_gdf = gpd.read_parquet(mosaic_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "mosaic_store = mosaic_index_gdf.iloc[0][\"location\"]\n",
+    "mosaic_store = mosaic_index.first_row_mosaic\n",
     "```"
    ]
   },

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -438,9 +438,8 @@
     "    nodata=0.0,\n",
     ")\n",
     "\n",
-    "mosaic_index_gdf = gpd.read_parquet(mosaic_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "mosaic_store = mosaic_index_gdf.iloc[0][\"location\"]\n",
+    "mosaic_store = mosaic_index.first_row_mosaic\n",
     "\n",
     "print(f\"Mosaic index URI: {mosaic_index.uri}\")\n",
     "print(f\"Mosaic store URI: {mosaic_store}\")"

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -124,9 +124,8 @@
     "    model_recipe = ModelRecipes.META_CHM_V1\n",
     ")\n",
     "\n",
-    "model_output_index_gdf = gpd.read_parquet(model_output_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "model_output_store = model_output_index_gdf.iloc[0][\"location\"]\n",
+    "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
     "print(model_output_index.uri)\n",
     "print(model_output_store)"

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -138,9 +138,8 @@
     "    end=datetime(2025, 1, 1),\n",
     ")\n",
     "\n",
-    "mosaic_index_gdf = gpd.read_parquet(mosaic_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "input_store = mosaic_index_gdf.iloc[0][\"location\"]\n",
+    "input_store = mosaic_index.first_row_mosaic\n",
     "\n",
     "print(mosaic_index.uri)\n",
     "print(input_store)"

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -255,9 +255,8 @@
     "    xy_block_multiplier=1\n",
     ")\n",
     "\n",
-    "model_output_index_gdf = gpd.read_parquet(model_output_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "model_output_store = model_output_index_gdf.iloc[0][\"location\"]\n",
+    "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
     "print(model_output_index.uri)\n",
     "print(model_output_store)"

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -124,9 +124,8 @@
     "    model_recipe = ModelRecipes.CHESAPEAKE_RSC\n",
     ")\n",
     "\n",
-    "model_output_index_gdf = gpd.read_parquet(model_output_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "model_output_store = model_output_index_gdf.iloc[0][\"location\"]\n",
+    "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
     "print(model_output_index.uri)\n",
     "print(model_output_store)"

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -138,9 +138,8 @@
     "    model_recipe = ModelRecipes.FTW,\n",
     ")\n",
     "\n",
-    "model_output_index_gdf = gpd.read_parquet(model_output_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "model_output_store = model_output_index_gdf.iloc[0][\"location\"]\n",
+    "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
     "print(model_output_index.uri)\n",
     "print(model_output_store)"

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -149,9 +149,8 @@
     "    crs_epsg=3857,\n",
     ")\n",
     "\n",
-    "mosaic_index_gdf = gpd.read_parquet(mosaic_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "mosaic_store = mosaic_index_gdf.iloc[0][\"location\"]\n",
+    "mosaic_store = mosaic_index.first_row_mosaic\n",
     "\n",
     "print(f\"Mosaic index URI: {mosaic_index.uri}\")\n",
     "print(f\"Mosaic store URI: {mosaic_store}\")"

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -128,9 +128,8 @@
     "    model_recipe = ModelRecipes.TILE_2_NET,\n",
     ")\n",
     "\n",
-    "model_output_index_gdf = gpd.read_parquet(model_output_index.uri)\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "model_output_store = model_output_index_gdf.iloc[0][\"location\"]\n",
+    "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
     "print(model_output_index.uri)\n",
     "print(model_output_store)"


### PR DESCRIPTION
## Summary
- Replace `gpd.read_parquet(mosaic_index.uri)` + `iloc[0]["location"]` with `mosaic_index.first_row_mosaic` in 3 notebooks:
  - `RasterFlow_S2_Mosaic.ipynb`
  - `RasterFlow_ChangeDetection.ipynb`
  - `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`

## Depends on
- wherobots/wherobots-rasterflow-remote#124

## Test plan
- [ ] Verify notebooks run end-to-end with updated rasterflow-remote