### PR TITLE
fix: bump Spark from 3.5.5 to 4.0.0

### DIFF
--- a/scala/packaging-example-project/pom.xml
+++ b/scala/packaging-example-project/pom.xml
@@ -13,8 +13,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.scope>test</dependency.scope>
         <geotoolswrapper.version>1.8.0-33.1</geotoolswrapper.version>
-        <spark.version>3.5.5</spark.version>
-        <spark.compat.version>3.5</spark.compat.version>
+        <spark.version>4.0.0</spark.version>
+        <spark.compat.version>4.0</spark.compat.version>
         <scala.version>2.13.10</scala.version>
         <scala.compat.version>2.13</scala.compat.version>
         <scala-collection-compat.version>2.5.0</scala-collection-compat.version>


### PR DESCRIPTION
## Summary
- Updates `spark.version` from 3.5.5 to 4.0.0 and `spark.compat.version` from 3.5 to 4.0
- Product now runs Spark 4.0; examples should match
- Also resolves Dependabot alert for spark-core < 3.5.7

## Test plan
- [ ] Verify `sedona-spark-4.0_2.13` and `iceberg-spark-runtime-4.0_2.13` artifacts resolve
- [ ] CI passes