### PR TITLE
fix: update RasterFlow notebook mosaic outputs

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -454,8 +454,7 @@
     "        resampling = ResamplingMethod.NEAREST,\n",
     "        nodata= 0.0,\n",
     ")\n",
-    "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "mosaic_store = mosaic_index.first_row_mosaic\n",
+    "mosaic_index.mosaics\n",
     "```"
    ]
   },
@@ -541,8 +540,20 @@
     "        **asdict(custom_inference_config)\n",
     ")\n",
     "\n",
+    "predict_mosaic_output.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-predict_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
-    "predict_store = predict_mosaic_output.first_row_mosaic"
+    "predict_store = predict_mosaic_output.first_row_mosaic\n",
+    "\n",
+    "predict_store"
    ]
   },
   {
@@ -560,7 +571,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predict_ds = xr.open_zarr(predict_store)"
+    "import xarray as xr\n",
+    "import s3fs\n",
+    "import zarr\n",
+    "\n",
+    "predict_fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "predict_zstore = zarr.storage.FsspecStore(predict_fs, path=predict_store[5:])\n",
+    "predict_ds = xr.open_zarr(predict_zstore)"
    ]
   },
   {
@@ -570,7 +587,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xr.open_zarr(mosaic_store)['variables']"
+    "mosaic_fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "mosaic_zstore = zarr.storage.FsspecStore(mosaic_fs, path=mosaic_store[5:])\n",
+    "xr.open_zarr(mosaic_zstore)['variables']"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -124,11 +124,20 @@
     "    model_recipe = ModelRecipes.META_CHM_V1\n",
     ")\n",
     "\n",
+    "model_output_index.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-model_output_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
-    "print(model_output_index.uri)\n",
-    "print(model_output_store)"
+    "model_output_store"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -138,11 +138,20 @@
     "    end=datetime(2025, 1, 1),\n",
     ")\n",
     "\n",
+    "mosaic_index.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-input_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "input_store = mosaic_index.first_row_mosaic\n",
     "\n",
-    "print(mosaic_index.uri)\n",
-    "print(input_store)"
+    "input_store"
    ]
   },
   {
@@ -161,8 +170,12 @@
    "outputs": [],
    "source": [
     "import xarray as xr\n",
+    "import s3fs\n",
+    "import zarr\n",
     "\n",
-    "mosaic = xr.open_zarr(input_store)\n",
+    "fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "zstore = zarr.storage.FsspecStore(fs, path=input_store[5:])\n",
+    "mosaic = xr.open_zarr(zstore)\n",
     "\n",
     "mosaic['variables']"
    ]
@@ -255,11 +268,20 @@
     "    xy_block_multiplier=1\n",
     ")\n",
     "\n",
+    "model_output_index.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-model_output_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
-    "print(model_output_index.uri)\n",
-    "print(model_output_store)"
+    "model_output_store"
    ]
   },
   {
@@ -277,7 +299,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_mosaic = xr.open_zarr(model_output_store)"
+    "import s3fs\n",
+    "import zarr\n",
+    "\n",
+    "fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "zstore = zarr.storage.FsspecStore(fs, path=model_output_store[5:])\n",
+    "result_mosaic = xr.open_zarr(zstore)"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -124,11 +124,20 @@
     "    model_recipe = ModelRecipes.CHESAPEAKE_RSC\n",
     ")\n",
     "\n",
+    "model_output_index.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-model_output_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
-    "print(model_output_index.uri)\n",
-    "print(model_output_store)"
+    "model_output_store"
    ]
   },
   {
@@ -161,8 +170,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import xarray as xr\n",
+    "import s3fs\n",
+    "import zarr\n",
     "# Determine the classes that are predicted by the model\n",
-    "model_features = xr.open_zarr(model_output_store)['band'].data.tolist()\n",
+    "fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "zstore = zarr.storage.FsspecStore(fs, path=model_output_store[5:])\n",
+    "ds = xr.open_zarr(zstore)\n",
+    "model_features = ds['band'].data.tolist()\n",
     "\n",
     "# Remove the 'background' class for vectorization\n",
     "vector_features = [f for f in model_features if f != 'background']  "

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -138,11 +138,20 @@
     "    model_recipe = ModelRecipes.FTW,\n",
     ")\n",
     "\n",
+    "model_output_index.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-model_output_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
-    "print(model_output_index.uri)\n",
-    "print(model_output_store)"
+    "model_output_store"
    ]
   },
   {
@@ -175,8 +184,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import xarray as xr\n",
+    "import s3fs\n",
+    "import zarr\n",
     "# Determine the classes that are predicted by the model\n",
-    "model_features = xr.open_zarr(model_output_store)['band'].data.tolist()\n",
+    "fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "zstore = zarr.storage.FsspecStore(fs, path=model_output_store[5:])\n",
+    "ds = xr.open_zarr(zstore)\n",
+    "model_features = ds['band'].data.tolist()\n",
     "\n",
     "# Remove the 'non_field_background' class for vectorization\n",
     "vector_features = [f for f in model_features if f != 'non_field_background']    "

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -145,11 +145,20 @@
     "    crs_epsg=3857,\n",
     ")\n",
     "\n",
+    "mosaic_index.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-mosaic_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "mosaic_store = mosaic_index.first_row_mosaic\n",
     "\n",
-    "print(f\"Mosaic index URI: {mosaic_index.uri}\")\n",
-    "print(f\"Mosaic store URI: {mosaic_store}\")"
+    "mosaic_store"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -128,11 +128,20 @@
     "    model_recipe = ModelRecipes.TILE_2_NET,\n",
     ")\n",
     "\n",
+    "model_output_index.mosaics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auto-model_output_store-selector",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "model_output_store = model_output_index.first_row_mosaic\n",
     "\n",
-    "print(model_output_index.uri)\n",
-    "print(model_output_store)"
+    "model_output_store"
    ]
   },
   {
@@ -165,8 +174,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import xarray as xr\n",
+    "import s3fs\n",
+    "import zarr\n",
     "# Determine the classes that are predicted by the model\n",
-    "model_features = xr.open_zarr(model_output_store)['band'].data.tolist()\n",
+    "fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
+    "zstore = zarr.storage.FsspecStore(fs, path=model_output_store[5:])\n",
+    "ds = xr.open_zarr(zstore)\n",
+    "model_features = ds['band'].data.tolist()\n",
     "\n",
     "# Only vectorize the 'sidewalk' and 'crosswalk' classes \n",
     "relevant_features = ['sidewalk', 'crosswalk']   \n",


### PR DESCRIPTION
- standardize RasterFlow notebooks to show MosaicResult dataframes before selecting the first store
- replace direct Zarr opens with the explicit s3fs/FsspecStore pattern in notebooks that inspect result stores
- keep notebook examples aligned around first_row_mosaic access and xarray usage

I tested the FTW nb, these changes are good to go.