### PR TITLE
docs: remove Wherobots-GL naming from RasterFlow notebooks

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -464,11 +464,9 @@
    "id": "53bdbd61",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map).\n",
-    "\n",
-    "Use the mosaic or inference output written in the preceding workflow steps, then open [cloud.wherobots.com/map](https://cloud.wherobots.com/map) to explore the results interactively.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -464,7 +464,7 @@
    "id": "53bdbd61",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -466,7 +466,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -15,7 +15,7 @@
     "- Query a STAC catalog to discover available imagery for an area of interest\n",
     "- Create a GTI (GDAL Raster Tile Index) from STAC items\n",
     "- Build a seamless mosaic from multiple image tiles using RasterFlow's `build_gti_mosaic`\n",
-    "- Visualize the resulting mosaic and inference outputs in Wherobots-GL\n",
+    "- Visualize the resulting mosaic and inference outputs\n",
     "- (Optional) Run road detection using the ChesapeakeRSC model"
    ]
   },
@@ -449,9 +449,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the mosaic and inference outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map). Wherobots-GL supports Zarr, GeoParquet, and other geospatial data formats, so you can inspect either the mosaic output or the road-probability output from the preceding workflow steps there.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the mosaic and inference outputs from this notebook using [cloud.wherobots.com/map](https://cloud.wherobots.com/map). Zarr, GeoParquet, and other geospatial data formats are supported, so you can inspect either the mosaic output or the road-probability output from the preceding workflow steps.\n"
    ]
   },
   {
@@ -503,7 +503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also open the road-probability output from the preceding inference workflow in [Wherobots-GL](https://cloud.wherobots.com/map) if RasterFlow is enabled for your organization.\n"
+    "You can also open the road-probability output from the preceding inference workflow using [cloud.wherobots.com/map](https://cloud.wherobots.com/map) if RasterFlow is enabled for your organization.\n"
    ]
   }
  ],

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -449,7 +449,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the mosaic and inference outputs from this notebook using [cloud.wherobots.com/map](https://cloud.wherobots.com/map). Zarr, GeoParquet, and other geospatial data formats are supported, so you can inspect either the mosaic output or the road-probability output from the preceding workflow steps.\n"
    ]

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -136,11 +136,9 @@
    "id": "26cffc31",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map).\n",
-    "\n",
-    "Use the mosaic or inference output written in the preceding workflow steps, then open [cloud.wherobots.com/map](https://cloud.wherobots.com/map) to explore the results interactively.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -136,7 +136,7 @@
    "id": "26cffc31",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -320,11 +320,9 @@
    "id": "722406c5",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map).\n",
-    "\n",
-    "Use the mosaic or inference output written in the preceding workflow steps, then open [cloud.wherobots.com/map](https://cloud.wherobots.com/map) to explore the results interactively.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -320,7 +320,7 @@
    "id": "722406c5",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -322,7 +322,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -136,7 +136,7 @@
    "id": "b573f45c",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -136,11 +136,9 @@
    "id": "b573f45c",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map).\n",
-    "\n",
-    "Use the mosaic or inference output written in the preceding workflow steps, then open [cloud.wherobots.com/map](https://cloud.wherobots.com/map) to explore the results interactively.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -150,7 +150,7 @@
    "id": "5738d7ce",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -150,11 +150,9 @@
    "id": "5738d7ce",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map).\n",
-    "\n",
-    "Use the mosaic or inference output written in the preceding workflow steps, then open [cloud.wherobots.com/map](https://cloud.wherobots.com/map) to explore the results interactively.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -152,7 +152,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -158,7 +158,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -156,11 +156,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map).\n",
-    "\n",
-    "Use the mosaic or inference output written in the preceding workflow steps, then open [cloud.wherobots.com/map](https://cloud.wherobots.com/map) to explore the results interactively.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {
@@ -172,7 +170,7 @@
     "This notebook demonstrated how to:\n",
     "\n",
     "1. Use RasterFlow to build a harvest-season Sentinel-2 median mosaic\n",
-    "2. Visualize the resulting outputs in Wherobots-GL\n",
+    "2. Visualize the resulting outputs\n",
     "\n",
     "### Next steps\n",
     "\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -140,11 +140,9 @@
    "id": "5edb29d3",
    "metadata": {},
    "source": [
-    "## Visualizing outputs in Wherobots-GL\n",
+    "## Visualizing outputs with RasterFlow\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs from this notebook in [Wherobots-GL](https://cloud.wherobots.com/map).\n",
-    "\n",
-    "Use the mosaic or inference output written in the preceding workflow steps, then open [cloud.wherobots.com/map](https://cloud.wherobots.com/map) to explore the results interactively.\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -142,7 +142,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -140,7 +140,7 @@
    "id": "5edb29d3",
    "metadata": {},
    "source": [
-    "## Visualizing outputs with RasterFlow\n",
+    "## Visualizing outputs\n",
     "\n",
     "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]


### PR DESCRIPTION
## Summary

- Follow-up to #151, which introduced references to "Wherobots-GL" in the RasterFlow solution notebooks. The visualization component should not be named at this time, so this PR replaces every "Wherobots-GL" mention (20 occurrences across 8 notebooks) with either a direct link to [cloud.wherobots.com/map](https://cloud.wherobots.com/map) or a RasterFlow-based phrasing.
- Also tightens the repetitive two-sentence "If RasterFlow is enabled… Use the mosaic or inference output… then open cloud.wherobots.com/map…" paragraph #151 added — collapsed into a single sentence.
- Guidance still directs readers to the same URL; no other cells are touched.

### Wording changes
- Section heading "Visualizing outputs in Wherobots-GL" → "Visualizing outputs"
- Body "…outputs from this notebook in [Wherobots-GL](…). Use the mosaic… then open cloud.wherobots.com/map to explore…" → "…outputs using [cloud.wherobots.com/map](…)."
- Bullets "Visualize … in Wherobots-GL" → "Visualize …" (terse form)

## Test plan

- [x] `grep -riE 'wherobots[- ]?gl|wherobotsgl'` returns zero matches in the repo
- [x] All modified notebooks `json.load` cleanly
- [x] `git diff main` is scoped to markdown-cell text only — no cell-id, output, or metadata churn
- [ ] Spot-render `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb` (has the most varied edits) in Jupyter to confirm the rewrites read naturally and the `cloud.wherobots.com/map` link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)