### PR TITLE
Change basemap in BYOR notebook to Esri to avoid OSM warnings

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -53,6 +53,7 @@
     "\n",
     "import geopandas as gpd\n",
     "import wkls\n",
+    "from ipyleaflet import basemaps\n",
     "from leafmap import Map"
    ]
   },
@@ -87,7 +88,7 @@
     "center_lat = (miny + maxy) / 2\n",
     "center_lon = (minx + maxx) / 2\n",
     "\n",
-    "m = Map(center=(center_lat, center_lon), zoom=10)\n",
+    "m = Map(center=(center_lat, center_lon), zoom=10, basemap=basemaps.Esri.WorldImagery)\n",
     "m.add_gdf(\n",
     "    gdf, \n",
     "    layer_name=\"Montgomery County, MD\", \n",
@@ -367,7 +368,7 @@
     "center_lat = (miny + maxy) / 2\n",
     "center_lon = (minx + maxx) / 2\n",
     "\n",
-    "m = Map(center=(center_lat, center_lon), zoom=10)\n",
+    "m = Map(center=(center_lat, center_lon), zoom=10, basemap=basemaps.Esri.WorldImagery)\n",
     "\n",
     "# Add NAIP tile footprints\n",
     "m.add_gdf(\n",


### PR DESCRIPTION
Change basemap to Esri to avoid OSM warnings

## Description

<!-- Describe your changes here -->

## Checklist

- [YES] I have tested these changes in Wherobots Cloud
- [YES] Notebooks follow the [style guide](../CONTRIBUTING.md#style-guide)

---

## For Release PRs (Wherobots Team Only)

If this PR is part of a wbc-images release, tags must be created after merging:

- [ ] I will create tags from `main` after merge (or tags are not needed for this PR)

**Tagging instructions:** Both v1 and v2 tags should typically point to the same commit unless you know otherwise.

```bash
git checkout main && git pull
git tag v1.X.Y && git tag v2.X.Y-preview
git push origin v1.X.Y v2.X.Y-preview
```

See [CONTRIBUTING.md](../CONTRIBUTING.md#wherobots-contributions) for details.
