### PR TITLE
fix: restore rasterflow notebook walkthroughs

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -454,6 +454,7 @@
     "        resampling = ResamplingMethod.NEAREST,\n",
     "        nodata= 0.0,\n",
     ")\n",
+    "mosaic_store = mosaic_index.first_row_mosaic\n",
     "mosaic_index.mosaics\n",
     "```"
    ]
@@ -495,12 +496,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "6c520ebc-6aa6-4e83-beb9-903287cbb987",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "```python\n",
     "from dataclasses import asdict\n",
     "from rasterflow_remote.data_models import InferenceConfig, MergeModeEnum, MosaicToMosaicActorEnum, ResamplingMethod\n",
     "\n",
@@ -515,7 +515,8 @@
     "    max_batch_size=64,\n",
     "    merge_mode = MergeModeEnum.WEIGHTED_AVERAGE\n",
     "    \n",
-    ")"
+    ")\n",
+    "```"
    ]
   },
   {
@@ -527,31 +528,31 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "2d1a023b-06bc-440d-8f72-97da438ac997",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "```python\n",
     "predict_mosaic_output = client.predict_mosaic(\n",
     "        store=mosaic_store,\n",
     "        **asdict(custom_inference_config)\n",
     ")\n",
     "\n",
-    "predict_mosaic_output.mosaics"
+    "predict_mosaic_output.mosaics\n",
+    "```"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "auto-predict_store-selector",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "```python\n",
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "predict_store = predict_mosaic_output.first_row_mosaic\n",
     "\n",
-    "predict_store"
+    "predict_store\n",
+    "```"
    ]
   },
   {
@@ -563,41 +564,41 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "277552e5-f610-49ba-9d44-1236b4ad9ced",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "```python\n",
     "import xarray as xr\n",
     "import s3fs\n",
     "import zarr\n",
     "\n",
     "predict_fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
     "predict_zstore = zarr.storage.FsspecStore(predict_fs, path=predict_store[5:])\n",
-    "predict_ds = xr.open_zarr(predict_zstore)"
+    "predict_ds = xr.open_zarr(predict_zstore)\n",
+    "```"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "09688799-90b5-422f-a0a3-ed82c006d25a",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "```python\n",
     "mosaic_fs = s3fs.S3FileSystem(profile=\"default\", asynchronous=True)\n",
     "mosaic_zstore = zarr.storage.FsspecStore(mosaic_fs, path=mosaic_store[5:])\n",
-    "xr.open_zarr(mosaic_zstore)['variables']"
+    "xr.open_zarr(mosaic_zstore)['variables']\n",
+    "```"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "74d20fc9-8922-4bfa-8674-cde81e0b9eab",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "predict_ds['variables']"
+    "```python\n",
+    "predict_ds['variables']\n",
+    "```"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -243,7 +243,7 @@
    "source": [
     "## Visualize the vectorized results\n",
     "\n",
-    "To visualize the vectorized results, we will choose a small subset of the outputs that intersect with a bounding box around the University of Maryland campus.  We will also filter out results with a score lower than 0.6."
+    "To visualize the vectorized results, we will choose a small subset of the outputs that intersect with a bounding box around the center of the AOI.  We will also filter out results with a score lower than 0.7."
    ]
   },
   {
@@ -257,10 +257,16 @@
     "from sedona.spark.sql.st_predicates import ST_Intersects\n",
     "import pyspark.sql.functions as f\n",
     "\n",
-    "min_lon = -77.07\n",
-    "max_lon = -77.05\n",
-    "min_lat = 39.17\n",
-    "max_lat = 39.19\n",
+    "# Compute a small bounding box around the center of the AOI\n",
+    "minx, miny, maxx, maxy = gdf.total_bounds\n",
+    "center_lat = (miny + maxy) / 2\n",
+    "center_lon = (minx + maxx) / 2\n",
+    "delta = 0.01\n",
+    "\n",
+    "min_lon = center_lon - delta\n",
+    "max_lon = center_lon + delta\n",
+    "min_lat = center_lat - delta\n",
+    "max_lat = center_lat + delta\n",
     "\n",
     "df = df.filter(\n",
     "    ST_Intersects(f.col(\"geometry\"), ST_MakeEnvelope(min_lon, min_lat, max_lon, max_lat))\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -257,6 +257,11 @@
     "from sedona.spark.sql.st_predicates import ST_Intersects\n",
     "import pyspark.sql.functions as f\n",
     "\n",
+    "min_lon = -77.07\n",
+    "max_lon = -77.05\n",
+    "min_lat = 39.17\n",
+    "max_lat = 39.19\n",
+    "\n",
     "df = df.filter(\n",
     "    ST_Intersects(f.col(\"geometry\"), ST_MakeEnvelope(min_lon, min_lat, max_lon, max_lat))\n",
     ").filter(\"score_mean > 0.7\")"


### PR DESCRIPTION
## Summary
- fix small inconsistency in the BYOM notebook walkthrough by defining `mosaic_store` in the markdown example and converting the later dependent walkthrough cells into markdown code blocks so notebook runs end to end
- restore the Chesapeake notebook's hardcoded bbox variables before the `ST_MakeEnvelope` filter so the notebook runs end-to-end again
- validate both edited notebooks still parse as JSON