### PR TITLE
docs: update S2 mosaic notebook to include ALL_BANDS example

### DIFF
--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Building Sentinel-2 seasonal mosaics with RasterFlow\n",
+    "# Building Sentinel-2 mosaics with RasterFlow\n",
     "\n",
     "This notebook demonstrates how to generate a harvest season Sentinel-2 median mosaic using Wherobots RasterFlow. You will learn how to define an Area of Interest, build a seasonal composite mosaic, and visualize the results as RGB imagery."
    ]
@@ -13,19 +13,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Sentinel-2 Harvest and Growing Season Mosaics\n",
+    "### Sentinel-2 Mosaics for Harvest and Growing Seasons or Custom Time Ranges\n",
     "\n",
     "RasterFlow provides pre-built seasonal mosaic datasets that use latitude-based heuristics to determine the optimal imaging window for agricultural analysis.  \n",
     "\n",
     "S2_MED_PLANTING: Sentinel-2 median composite dataset for planting season.\n",
+    "\n",
     "S2_MED_HARVEST: Sentinel-2 median composite dataset for harvest season.\n",
+    "\n",
+    "S2_MED_WINDOWED_PIXEL_ALL_BANDS: Sentinel-2 median composite over a user-specified date window, returning all 12 L2A spectral bands at 10m. No season heuristic is applied.\n",
     "\n",
     "In this example, we will generate a mosaic for the harvest season.  The mosaic contains 5 bands:\n",
     "- `s2med_harvest:B02` - Blue (10m)\n",
     "- `s2med_harvest:B03` - Green (10m)\n",
     "- `s2med_harvest:B04` - Red (10m)\n",
     "- `s2med_harvest:B08` - NIR (10m)\n",
-    "- `s2med_harvest:N_VALID_PIXELS` - Count of valid pixels used in the median calculation"
+    "- `s2med_harvest:N_VALID_PIXELS` - Count of valid pixels used in the median calculation\n",
+    "\n",
+    "After the harvest mosaic, we'll build a second mosaic over the same AOI using `S2_MED_WINDOWED_PIXEL_ALL_BANDS` to show how to get all 12 spectral bands over a custom date window."
    ]
   },
   {
@@ -167,7 +172,48 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "If RasterFlow is enabled for your organization, you can visualize the Zarr outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building an ALL_BANDS mosaic over a custom window\n",
+    "\n",
+    "Pick the `S2_MED_WINDOWED_PIXEL_ALL_BANDS` dataset when:\n",
+    "\n",
+    "- You need a **specific date window** (e.g., a single month, or pre/post a known event) — `start` and `end` are used directly, with no latitude-based seasonal filtering.\n",
+    "- You need bands beyond RGB+NIR — for example **red-edge** (B05, B06, B07, B8A), **water vapor** (B09), or **SWIR** (B11, B12) bands for indices like NDMI, NBR, or NDWI.\n",
+    "\n",
+    "The mosaic contains 12 bands at 10m: B01, B02, B03, B04, B05, B06, B07, B08, B8A, B09, B11, B12 (B10 is excluded because it isn't part of L2A).\n",
+    "\n",
+    "Cloud and quality filtering and the median composition step are the same as for the harvest mosaic above. We'll reuse the AOI we wrote to S3 and build a peak-vegetation summer composite for July–August 2024."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_bands_index = rf_client.build_mosaic(\n",
+    "    # All 12 L2A spectral bands, median composite over the date window below\n",
+    "    datasets=[DatasetEnum.S2_MED_WINDOWED_PIXEL_ALL_BANDS],\n",
+    "    \n",
+    "    # Reuse the same AOI as the harvest example\n",
+    "    aoi=aoi_path,\n",
+    "    \n",
+    "    # Custom date window — used directly, no seasonal heuristic\n",
+    "    start=datetime(2024, 7, 1),\n",
+    "    end=datetime(2024, 9, 1),\n",
+    "    \n",
+    "    # Output CRS (Web Mercator)\n",
+    "    crs_epsg=3857,\n",
+    ")\n",
+    "\n",
+    "all_bands_store = all_bands_index.first_row_mosaic\n",
+    "print(f\"All-bands mosaic store: {all_bands_store}\")"
    ]
   },
   {
@@ -179,7 +225,7 @@
     "This notebook demonstrated how to:\n",
     "\n",
     "1. Use RasterFlow to build a harvest-season Sentinel-2 median mosaic\n",
-    "2. Visualize the resulting outputs\n",
+    "2. Build a custom-window all-bands Sentinel-2 mosaic with `S2_MED_WINDOWED_PIXEL_ALL_BANDS`\n",
     "\n",
     "### Next steps\n",
     "\n",


### PR DESCRIPTION
## Summary

- Adds a runnable example using `DatasetEnum.S2_MED_WINDOWED_PIXEL_ALL_BANDS` so readers know how to opt out of the latitude-based seasonal heuristic and get all 12 L2A bands.
- Reuses the same Haskell County, Kansas AOI from the harvest example, with a Jul–Aug 2024 window so the two outputs are directly comparable.
- Updates the intro markdown to list the new dataset alongside `S2_MED_PLANTING` / `S2_MED_HARVEST`.

Reference: [data-models#param-s2-med-windowed-pixel-all-bands](https://docs.wherobots.com/reference/rasterflow/data-models#param-s2-med-windowed-pixel-all-bands)

## Test plan

- [ ] Open the notebook and confirm the new section renders cleanly between *Visualizing outputs* and *Summary*
- [ ] On a Wherobots runtime with RasterFlow enabled, run the new `build_mosaic` cell and confirm `all_bands_index.first_row_mosaic` returns a Zarr URI under `USER_S3_PATH`
- [ ] Re-run the existing harvest cell to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)