### PR TITLE
refactor: update notebooks for renamed rasterflow sdk methods

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -440,7 +440,7 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "mosaic_index = client.build_gti_mosaic(\n",
+    "mosaic_index = client.build_gti_mosaics(\n",
     "        gti = \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "        aoi = aoi_path,\n",
     "        bands = [\"red\", \"green\", \"blue\", \"nir\"],\n",
@@ -534,7 +534,7 @@
    "source": [
     "```python\n",
     "predict_mosaic_output = client.predict_mosaic(\n",
-    "        store=mosaic_store,\n",
+    "        mosaics=mosaic_store,\n",
     "        **asdict(custom_inference_config)\n",
     ")\n",
     "\n",
@@ -615,7 +615,7 @@
     "- **Define input shape constraints** using `torch.export.Dim` for dynamic batch sizes and fixed spatial dimensions\n",
     "- **Export models and transforms** together into a single `.pt2` archive using `package_pt2`\n",
     "- **Upload custom models to S3** using Wherobots Managed Storage\n",
-    "- **Build GTI mosaics** from imagery indexes with `build_gti_mosaic`\n",
+    "- **Build GTI mosaics** from imagery indexes with `build_gti_mosaics`\n",
     "- **Run scalable inference** using `InferenceConfig` and `predict_mosaic`\n",
     "\n",
     "### Next Steps\n",

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Bring Your Own Rasters (BYOR) with RasterFlow\n",
     "\n",
-    "This notebook demonstrates how to bring your own rasters (BYOR) into RasterFlow by querying a STAC catalog and creating a GTI (GDAL Raster Tile Index). You will learn how to query the NAIP collection, extract Cloud-Optimized GeoTIFF (COG) URLs, and build a mosaic using RasterFlow's `build_gti_mosaic` function.\n",
+    "This notebook demonstrates how to bring your own rasters (BYOR) into RasterFlow by querying a STAC catalog and creating a GTI (GDAL Raster Tile Index). You will learn how to query the NAIP collection, extract Cloud-Optimized GeoTIFF (COG) URLs, and build a mosaic using RasterFlow's `build_gti_mosaics` function.\n",
     "\n",
     "## What you will learn\n",
     "\n",
@@ -14,7 +14,7 @@
     "\n",
     "- Query a STAC catalog to discover available imagery for an area of interest\n",
     "- Create a GTI (GDAL Raster Tile Index) from STAC items\n",
-    "- Build a seamless mosaic from multiple image tiles using RasterFlow's `build_gti_mosaic`\n",
+    "- Build a seamless mosaic from multiple image tiles using RasterFlow's `build_gti_mosaics`\n",
     "- Visualize the resulting mosaic and inference outputs\n",
     "- (Optional) Run road detection using the ChesapeakeRSC model"
    ]
@@ -395,7 +395,7 @@
    "source": [
     "## Building a mosaic with RasterFlow\n",
     "\n",
-    "Now we use RasterFlow's `build_gti_mosaic` function to create a seamless 4-band mosaic from the NAIP tiles.\n",
+    "Now we use RasterFlow's `build_gti_mosaics` function to create a seamless 4-band mosaic from the NAIP tiles.\n",
     "\n",
     "> **Note:** The `naip-analytic` S3 bucket is requester-pays, so we set `requester_pays=True`.\n",
     "\n",
@@ -413,7 +413,7 @@
     "client = RasterflowClient()\n",
     "\n",
     "# Build a 4-band mosaic (Red, Green, Blue, NIR)\n",
-    "mosaic_index = client.build_gti_mosaic(\n",
+    "mosaic_index = client.build_gti_mosaics(\n",
     "    # Path to the GTI GeoParquet file\n",
     "    gti=os.getenv(\"USER_S3_PATH\") + \"naip_gti.parquet\",\n",
     "    \n",
@@ -485,7 +485,7 @@
     "# MODEL_PATH = \"https://huggingface.co/wherobots/chesapeakersc-pt2/resolve/main/chesapeakersc-ep.pt2\"\n",
     "# \n",
     "# prediction_store = client.predict_mosaic(\n",
-    "#     store=mosaic_store,\n",
+    "#     mosaics=mosaic_store,\n",
     "#     model_path=MODEL_PATH,\n",
     "#     patch_size=512,\n",
     "#     clip_size=64,\n",

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_output_index = rf_client.build_and_predict_mosaic_recipe(\n",
+    "model_output_index = rf_client.predict_mosaic_recipe(\n",
     "    # Path to our AOI in GeoParquet or GeoJSON format\n",
     "    aoi = aoi_path,\n",
     "\n",

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -386,7 +386,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        mosaics = model_output_store,\n",
+    "        mosaic = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.5,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -114,7 +114,7 @@
    "source": [
     "## Building a Mosaic\n",
     "\n",
-    "RasterFlow provides a `build_mosaic` workflow to create analysis-ready imagery for your Area of Interest (AOI). This step:\n",
+    "RasterFlow provides a `build_mosaics` workflow to create analysis-ready imagery for your Area of Interest (AOI). This step:\n",
     "* Ingests Sentinel-2 imagery for the specified AOI across your defined time range (e.g., 2 years)\n",
     "* Applies [quality filtering and cloud masking](https://docs.wherobots.com/develop/rasterflow/rasterflow-datasets#cloud-and-quality-filtering) to select valid observations\n",
     "* Generates a seamless, temporally-composited mosaic from multiple image tiles\n",
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mosaic_index = rf_client.build_mosaic(\n",
+    "mosaic_index = rf_client.build_mosaics(\n",
     "    datasets=[DatasetEnum.S2_MED_WINDOWED_PIXEL],\n",
     "    aoi=aoi_path,\n",
     "    start=datetime(2023, 1, 1),\n",
@@ -209,7 +209,7 @@
     "\n",
     "We'll pass in the band names we want to predict, as well as other inference configs that specify how to run inference.\n",
     "\n",
-    "- `store` is the mosaic we just created for sentinel-2\n",
+    "- `mosaics` is the mosaic we just created for sentinel-2\n",
     "- `model_path` can be a path to a Pytorch 2 Archive file on s3 or Huggingface. In this case we'll use the Fields of the World model from the Wherobots' Huggingface Collection.\n",
     "- `patch_size` controls the XY size of the array input to the model\n",
     "- `clip_size` in conjunction with `MergeModeEnum`, controls how to run overlapping windowed inference to reduce edge effects relative to non-overlapping inference\n",
@@ -246,7 +246,7 @@
    "outputs": [],
    "source": [
     "model_output_index = rf_client.predict_mosaic(\n",
-    "    store=input_store,\n",
+    "    mosaics=input_store,\n",
     "    model_path=\"https://huggingface.co/wherobots/ftw-v1.1-pt2/resolve/main/ftw-v1.1-ep.pt2\",\n",
     "    patch_size=256,\n",
     "    clip_size=32,\n",
@@ -386,7 +386,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        store = model_output_store,\n",
+    "        mosaics = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.5,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_output_index = rf_client.build_and_predict_mosaic_recipe(\n",
+    "model_output_index = rf_client.predict_mosaic_recipe(\n",
     "    # Path to our AOI in GeoParquet or GeoJSON format\n",
     "    aoi = aoi_path,\n",
     "\n",
@@ -190,7 +190,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        store = model_output_store,\n",
+    "        mosaics = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.5,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -190,7 +190,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        mosaics = model_output_store,\n",
+    "        mosaic = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.5,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_output_index = rf_client.build_and_predict_mosaic_recipe(\n",
+    "model_output_index = rf_client.predict_mosaic_recipe(\n",
     "    # Path to our AOI in GeoParquet or GeoJSON format\n",
     "    aoi = aoi_path,\n",
     "\n",
@@ -204,7 +204,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        store = model_output_store,\n",
+    "        mosaics = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.5,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -204,7 +204,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        mosaics = model_output_store,\n",
+    "        mosaic = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.5,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -111,7 +111,7 @@
     "4. Compute a pixel-wise median composite across remaining valid observations\n",
     "5. Output the result as a Zarr store\n",
     "\n",
-    "> **Note:** This step will take approximately 10-15 minutes to complete.  If you want to skip this build_mosaic step, you can uncomment the next cell and start with a pre-generated mosaic."
+    "> **Note:** This step will take approximately 10-15 minutes to complete.  If you want to skip this build_mosaics step, you can uncomment the next cell and start with a pre-generated mosaic."
    ]
   },
   {
@@ -130,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mosaic_index = rf_client.build_mosaic(\n",
+    "mosaic_index = rf_client.build_mosaics(\n",
     "    # Dataset type for harvest season median mosaic\n",
     "    datasets=[DatasetEnum.S2_MED_HARVEST],\n",
     "    \n",

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_output = rf_client.run_geometry_inference_recipe(\n",
+    "model_output = rf_client.predict_mosaic_geometries_recipe(\n",
     "    # Path to our AOI in GeoParquet or GeoJSON format\n",
     "    aoi=aoi_path,\n",
     "\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -195,7 +195,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        mosaics = model_output_store,\n",
+    "        mosaic = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.05,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_output_index = rf_client.build_and_predict_mosaic_recipe(\n",
+    "model_output_index = rf_client.predict_mosaic_recipe(\n",
     "    # Path to our AOI in GeoParquet or GeoJSON format\n",
     "    aoi = aoi_path,\n",
     "\n",
@@ -195,7 +195,7 @@
    "source": [
     "# Note: this should take about 5 minutes to complete\n",
     "vectorized_results = rf_client.vectorize_mosaic(\n",
-    "        store = model_output_store,\n",
+    "        mosaics = model_output_store,\n",
     "        features = vector_features,\n",
     "        threshold = 0.05,\n",
     "        vectorize_method = VectorizeMethodEnum.SEMANTIC_SEGMENTATION_RASTERIO,\n",


### PR DESCRIPTION
## Summary
Aligns RasterFlow notebook calls with renamed SDK methods:
- `build_mosaic` → `build_mosaics`
- `build_gti_mosaic` → `build_gti_mosaics`
- `build_and_predict_mosaic_recipe` → `predict_mosaic_recipe`
- `run_geometry_inference_recipe` → `predict_mosaic_geometries_recipe`

And renames `store=` kwarg to `mosaics=` for `predict_mosaic`, `predict_mosaic_geometries`, `run_mosaics_change`

Depends on `wherobots-rasterflow-remote` PR release.

## Test plan
- [ ] Re-run impacted notebooks against new SDK release