### PR TITLE
Add optional build_zarr_multiscales step to RasterFlow notebooks

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -448,6 +448,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "11fa830d",
+   "metadata": {},
+   "source": [
+    "## (Optional) Build an optimized Zarr for visualization\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "\n",
+    "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d5b14c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optimized_store = client.build_zarr_multiscales(source_store=mosaic_store)\n",
+    "# optimized_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Visualizing outputs\n",

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -147,6 +147,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f244c738",
+   "metadata": {},
+   "source": [
+    "## (Optional) Build an optimized Zarr for visualization\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "\n",
+    "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "211474f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optimized_store = rf_client.build_zarr_multiscales(source_store=model_output_store)\n",
+    "# optimized_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "26cffc31",
    "metadata": {},
    "source": [

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -286,6 +286,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "826c34a0",
+   "metadata": {},
+   "source": [
+    "## (Optional) Build an optimized Zarr for visualization\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "\n",
+    "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82db6e55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optimized_store = rf_client.build_zarr_multiscales(source_store=model_output_store)\n",
+    "# optimized_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "298d9c00-9eaa-4c9f-864a-afe766120622",
    "metadata": {},
    "source": [

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -147,6 +147,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "786623d8",
+   "metadata": {},
+   "source": [
+    "## (Optional) Build an optimized Zarr for visualization\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "\n",
+    "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddbe1f79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optimized_store = rf_client.build_zarr_multiscales(source_store=model_output_store)\n",
+    "# optimized_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b573f45c",
    "metadata": {},
    "source": [

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -161,6 +161,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8f472ed5",
+   "metadata": {},
+   "source": [
+    "## (Optional) Build an optimized Zarr for visualization\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "\n",
+    "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "460e2bef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optimized_store = rf_client.build_zarr_multiscales(source_store=model_output_store)\n",
+    "# optimized_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5738d7ce",
    "metadata": {},
    "source": [

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -168,6 +168,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ed258752",
+   "metadata": {},
+   "source": [
+    "## (Optional) Build an optimized Zarr for visualization\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "\n",
+    "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b245a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optimized_store = rf_client.build_zarr_multiscales(source_store=mosaic_store)\n",
+    "# The same call works on the all-bands store: build_zarr_multiscales(source_store=all_bands_store)\n",
+    "# optimized_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Visualizing outputs\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -151,6 +151,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cc4bed9e",
+   "metadata": {},
+   "source": [
+    "## (Optional) Build an optimized Zarr for visualization\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "\n",
+    "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4a970dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optimized_store = rf_client.build_zarr_multiscales(source_store=model_output_store)\n",
+    "# optimized_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5edb29d3",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## What

Adds an optional, **commented-out-by-default** step to each RasterFlow solution notebook that produces a raster (Zarr) output, demonstrating how to build an *optimized* multiscale Zarr for interactive visualization on [cloud.wherobots.com/map](https://cloud.wherobots.com/map).

Each notebook gets two new cells inserted right after the cell that produces the output Zarr:

1. A short markdown description of what `build_zarr_multiscales` does (adds downsampled overview pyramids so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in).
2. A commented-out code cell calling `client.build_zarr_multiscales(source_store=...)`.

The code is commented out so the notebooks run end-to-end unchanged; users opt in by uncommenting.

## Notebooks updated (7)

- `RasterFlow_ChangeDetection.ipynb`
- `RasterFlow_Chesapeake.ipynb`
- `RasterFlow_FTW.ipynb`
- `RasterFlow_CHM.ipynb`
- `RasterFlow_Tile2Net.ipynb`
- `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb` (uses `client` / `mosaic_store`)
- `RasterFlow_S2_Mosaic.ipynb` (uses `mosaic_store`; markdown notes the same call works on `all_bands_store`)

The correct client variable (`rf_client` vs `client`) and source-store variable (`model_output_store` vs `mosaic_store`) is used per notebook.

SAM3 notebooks are excluded since they produce vector (GeoParquet) outputs, not rasters.