### PR TITLE
feat: use examples_temp catalog for temporary results

### DIFF
--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -443,11 +443,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS org_catalog.ftw_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.ftw_db\")\n",
     "\n",
     "vectorize_result_df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "vectorize_result_df = vectorize_result_df.withColumnRenamed(\"label\", \"layer\")\n",
-    "vectorize_result_df.writeTo(\"org_catalog.ftw_db.ftw_vectorized\").createOrReplace()"
+    "vectorize_result_df.writeTo(\"example_temp.ftw_db.ftw_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -443,11 +443,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.ftw_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS examples_temp.ftw_db\")\n",
     "\n",
     "vectorize_result_df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "vectorize_result_df = vectorize_result_df.withColumnRenamed(\"label\", \"layer\")\n",
-    "vectorize_result_df.writeTo(\"example_temp.ftw_db.ftw_vectorized\").createOrReplace()"
+    "vectorize_result_df.writeTo(\"examples_temp.ftw_db.ftw_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -273,11 +273,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS org_catalog.chesapeake_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.chesapeake_db\")\n",
     "\n",
     "df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "df = df.withColumnRenamed(\"label\", \"layer\")\n",
-    "df.writeTo(\"org_catalog.chesapeake_db.chesapeake_vectorized\").createOrReplace()"
+    "df.writeTo(\"example_temp.chesapeake_db.chesapeake_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -273,11 +273,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.chesapeake_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS examples_temp.chesapeake_db\")\n",
     "\n",
     "df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "df = df.withColumnRenamed(\"label\", \"layer\")\n",
-    "df.writeTo(\"example_temp.chesapeake_db.chesapeake_vectorized\").createOrReplace()"
+    "df.writeTo(\"examples_temp.chesapeake_db.chesapeake_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -285,11 +285,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.ftw_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS examples_temp.ftw_db\")\n",
     "\n",
     "vectorize_result_df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "vectorize_result_df = vectorize_result_df.withColumnRenamed(\"label\", \"layer\")\n",
-    "vectorize_result_df.writeTo(\"example_temp.ftw_db.ftw_vectorized\").createOrReplace()"
+    "vectorize_result_df.writeTo(\"examples_temp.ftw_db.ftw_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -285,11 +285,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS org_catalog.ftw_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.ftw_db\")\n",
     "\n",
     "vectorize_result_df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "vectorize_result_df = vectorize_result_df.withColumnRenamed(\"label\", \"layer\")\n",
-    "vectorize_result_df.writeTo(\"org_catalog.ftw_db.ftw_vectorized\").createOrReplace()"
+    "vectorize_result_df.writeTo(\"example_temp.ftw_db.ftw_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -200,11 +200,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS org_catalog.sam3_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.sam3_db\")\n",
     "\n",
     "df = sedona.read.format(\"geoparquet\").load(model_output.uri)\n",
     "df = df.withColumnRenamed(\"label\", \"layer\")\n",
-    "df.writeTo(\"org_catalog.sam3_db.sam3_roofs\").createOrReplace()"
+    "df.writeTo(\"example_temp.sam3_db.sam3_roofs\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -200,11 +200,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.sam3_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS examples_temp.sam3_db\")\n",
     "\n",
     "df = sedona.read.format(\"geoparquet\").load(model_output.uri)\n",
     "df = df.withColumnRenamed(\"label\", \"layer\")\n",
-    "df.writeTo(\"example_temp.sam3_db.sam3_roofs\").createOrReplace()"
+    "df.writeTo(\"examples_temp.sam3_db.sam3_roofs\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -282,11 +282,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS org_catalog.tile2net_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.tile2net_db\")\n",
     "\n",
     "df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "df = df.withColumnRenamed(\"label\", \"layer\")\n",
-    "df.writeTo(\"org_catalog.tile2net_db.tile2net_vectorized\").createOrReplace()"
+    "df.writeTo(\"example_temp.tile2net_db.tile2net_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -282,11 +282,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS example_temp.tile2net_db\")\n",
+    "sedona.sql(\"CREATE DATABASE IF NOT EXISTS examples_temp.tile2net_db\")\n",
     "\n",
     "df = sedona.read.format(\"geoparquet\").load(vectorized_results.uri)\n",
     "df = df.withColumnRenamed(\"label\", \"layer\")\n",
-    "df.writeTo(\"example_temp.tile2net_db.tile2net_vectorized\").createOrReplace()"
+    "df.writeTo(\"examples_temp.tile2net_db.tile2net_vectorized\").createOrReplace()"
    ]
   },
   {

--- a/Analyzing_Data/Zonal_Stats_ESAWorldCover_Texas.ipynb
+++ b/Analyzing_Data/Zonal_Stats_ESAWorldCover_Texas.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(f\"\"\"CREATE DATABASE IF NOT EXISTS example_temp.{YOUR_DATABASE_NAME}\"\"\")"
+    "sedona.sql(f\"\"\"CREATE DATABASE IF NOT EXISTS examples_temp.{YOUR_DATABASE_NAME}\"\"\")"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "source": [
     "# Persist as a raster table in Iceberg\n",
     "sedona.sql(f\"\"\"\n",
-    "CREATE OR REPLACE TABLE example_temp.{YOUR_DATABASE_NAME}.esa_world_cover\n",
+    "CREATE OR REPLACE TABLE examples_temp.{YOUR_DATABASE_NAME}.esa_world_cover\n",
     "AS\n",
     "SELECT * FROM esa_outdb_rasters\n",
     "\"\"\")\n",
@@ -193,7 +193,7 @@
     "# Persist buildings as a raster table in Iceberg\n",
     "\n",
     "sedona.sql(f\"\"\"\n",
-    "CREATE OR REPLACE TABLE example_temp.{YOUR_DATABASE_NAME}.texas_buildings\n",
+    "CREATE OR REPLACE TABLE examples_temp.{YOUR_DATABASE_NAME}.texas_buildings\n",
     "AS\n",
     "SELECT * FROM buildings_filtered\n",
     "\"\"\")"
@@ -219,9 +219,9 @@
     "  p.id,\n",
     "  RS_ZonalStatsAll(r.rast, p.buffer, 1) AS stats\n",
     "FROM\n",
-    "  example_temp.{YOUR_DATABASE_NAME}.texas_buildings p\n",
+    "  examples_temp.{YOUR_DATABASE_NAME}.texas_buildings p\n",
     "JOIN\n",
-    "  example_temp.{YOUR_DATABASE_NAME}.esa_world_cover r\n",
+    "  examples_temp.{YOUR_DATABASE_NAME}.esa_world_cover r\n",
     "  ON RS_Intersects(r.rast, p.buffer)\n",
     "\"\"\")\n",
     "\n",

--- a/Analyzing_Data/Zonal_Stats_ESAWorldCover_Texas.ipynb
+++ b/Analyzing_Data/Zonal_Stats_ESAWorldCover_Texas.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sedona.sql(f\"\"\"CREATE DATABASE IF NOT EXISTS org_catalog.{YOUR_DATABASE_NAME}\"\"\")"
+    "sedona.sql(f\"\"\"CREATE DATABASE IF NOT EXISTS example_temp.{YOUR_DATABASE_NAME}\"\"\")"
    ]
   },
   {
@@ -125,7 +125,7 @@
    "source": [
     "# Persist as a raster table in Iceberg\n",
     "sedona.sql(f\"\"\"\n",
-    "CREATE OR REPLACE TABLE org_catalog.{YOUR_DATABASE_NAME}.esa_world_cover\n",
+    "CREATE OR REPLACE TABLE example_temp.{YOUR_DATABASE_NAME}.esa_world_cover\n",
     "AS\n",
     "SELECT * FROM esa_outdb_rasters\n",
     "\"\"\")\n",
@@ -193,7 +193,7 @@
     "# Persist buildings as a raster table in Iceberg\n",
     "\n",
     "sedona.sql(f\"\"\"\n",
-    "CREATE OR REPLACE TABLE org_catalog.{YOUR_DATABASE_NAME}.texas_buildings\n",
+    "CREATE OR REPLACE TABLE example_temp.{YOUR_DATABASE_NAME}.texas_buildings\n",
     "AS\n",
     "SELECT * FROM buildings_filtered\n",
     "\"\"\")"
@@ -219,9 +219,9 @@
     "  p.id,\n",
     "  RS_ZonalStatsAll(r.rast, p.buffer, 1) AS stats\n",
     "FROM\n",
-    "  org_catalog.{YOUR_DATABASE_NAME}.texas_buildings p\n",
+    "  example_temp.{YOUR_DATABASE_NAME}.texas_buildings p\n",
     "JOIN\n",
-    "  org_catalog.{YOUR_DATABASE_NAME}.esa_world_cover r\n",
+    "  example_temp.{YOUR_DATABASE_NAME}.esa_world_cover r\n",
     "  ON RS_Intersects(r.rast, p.buffer)\n",
     "\"\"\")\n",
     "\n",

--- a/Getting_Started/Part_3_Accelerating_Geospatial_Datasets.ipynb
+++ b/Getting_Started/Part_3_Accelerating_Geospatial_Datasets.ipynb
@@ -125,7 +125,7 @@
     "\n",
     "# Create a Database\n",
     "sedona.sql(f'''\n",
-    "CREATE DATABASE IF NOT EXISTS example_temp.{name}\n",
+    "CREATE DATABASE IF NOT EXISTS examples_temp.{name}\n",
     "''')"
    ]
   },
@@ -138,7 +138,7 @@
    "source": [
     "# Create the table and add a point geometry column\n",
     "sedona.sql(f'''\n",
-    "CREATE OR REPLACE TABLE example_temp.{name}.gdelt AS \n",
+    "CREATE OR REPLACE TABLE examples_temp.{name}.gdelt AS \n",
     "SELECT *, \n",
     "ST_SetSRID(\n",
     "    ST_Point(ActionGeo_Long, ActionGeo_Lat),\n",
@@ -156,7 +156,7 @@
    "source": [
     "Here's how we did it.\n",
     "\n",
-    "- The `CREATE DATABASE` command creates the `example_temp.gdelt` database if it doesn’t already exist.\n",
+    "- The `CREATE DATABASE` command creates the `examples_temp.gdelt` database if it doesn’t already exist.\n",
     "- `CREATE OR REPLACE TABLE` makes a managed table by selecting data from the temporary view.\n",
     "- We also created a **geometry column** using the latitude and longitude fields from the CSV.\n",
     "  - We use `ST_Point` to create a point geometry from the latitude and longitude\n",
@@ -205,7 +205,7 @@
     "*,\n",
     "ST_GeoHash(geometry, 15) AS geohash,\n",
     "struct(st_xmin(geometry) as xmin, st_ymin(geometry) as ymin, st_xmax(geometry) as xmax, st_ymax(geometry) as ymax) as bbox\n",
-    "FROM example_temp.{name}.gdelt''')"
+    "FROM examples_temp.{name}.gdelt''')"
    ]
   },
   {

--- a/Getting_Started/Part_3_Accelerating_Geospatial_Datasets.ipynb
+++ b/Getting_Started/Part_3_Accelerating_Geospatial_Datasets.ipynb
@@ -125,7 +125,7 @@
     "\n",
     "# Create a Database\n",
     "sedona.sql(f'''\n",
-    "CREATE DATABASE IF NOT EXISTS org_catalog.{name}\n",
+    "CREATE DATABASE IF NOT EXISTS example_temp.{name}\n",
     "''')"
    ]
   },
@@ -138,7 +138,7 @@
    "source": [
     "# Create the table and add a point geometry column\n",
     "sedona.sql(f'''\n",
-    "CREATE OR REPLACE TABLE org_catalog.{name}.gdelt AS \n",
+    "CREATE OR REPLACE TABLE example_temp.{name}.gdelt AS \n",
     "SELECT *, \n",
     "ST_SetSRID(\n",
     "    ST_Point(ActionGeo_Long, ActionGeo_Lat),\n",
@@ -156,7 +156,7 @@
    "source": [
     "Here's how we did it.\n",
     "\n",
-    "- The `CREATE DATABASE` command creates the `org_catalog.gdelt` database if it doesn’t already exist.\n",
+    "- The `CREATE DATABASE` command creates the `example_temp.gdelt` database if it doesn’t already exist.\n",
     "- `CREATE OR REPLACE TABLE` makes a managed table by selecting data from the temporary view.\n",
     "- We also created a **geometry column** using the latitude and longitude fields from the CSV.\n",
     "  - We use `ST_Point` to create a point geometry from the latitude and longitude\n",
@@ -205,7 +205,7 @@
     "*,\n",
     "ST_GeoHash(geometry, 15) AS geohash,\n",
     "struct(st_xmin(geometry) as xmin, st_ymin(geometry) as ymin, st_xmax(geometry) as xmax, st_ymax(geometry) as ymax) as bbox\n",
-    "FROM org_catalog.{name}.gdelt''')"
+    "FROM example_temp.{name}.gdelt''')"
    ]
   },
   {


### PR DESCRIPTION
## What

Replaces `org_catalog` with `examples_temp` across 7 example notebooks (19 occurrences: `CREATE DATABASE`, `writeTo`, `CREATE OR REPLACE TABLE`, `FROM` clauses, and one markdown explainer).

## Why

`org_catalog` lives in a specific bucket that isn't accessible to all workloads — notably **BYOC** workloads. `examples_temp` is a Hadoop-type Iceberg catalog backed by the region temp bucket, available to every workload, intended for scratch/temporary results.

## Notebooks changed

- `Analyzing_Data/RasterFlow_SAM3.ipynb`
- `Analyzing_Data/RasterFlow_ChangeDetection.ipynb`
- `Analyzing_Data/RasterFlow_Chesapeake.ipynb`
- `Analyzing_Data/RasterFlow_FTW.ipynb`
- `Analyzing_Data/RasterFlow_Tile2Net.ipynb`
- `Analyzing_Data/Zonal_Stats_ESAWorldCover_Texas.ipynb`
- `Getting_Started/Part_3_Accelerating_Geospatial_Datasets.ipynb`

> Requires the companion PR in studio-backend that defines the `examples_temp` catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)