### PR TITLE
fix: update RasterFlow notebook CRS arguments

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -446,7 +446,7 @@
     "        bands = [\"red\", \"green\", \"blue\", \"nir\"],\n",
     "        location_field = \"url\",\n",
     "        time_column = \"year\",\n",
-    "        crs_epsg = 3857,\n",
+    "        target_crs = 3857,\n",
     "        xy_chunksize = 1024,\n",
     "        query = \"res == .6\",\n",
     "        requester_pays = True,\n",

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -425,7 +425,7 @@
     "    time_column=\"datetime\",\n",
     "    \n",
     "    # Output CRS (UTM Zone 18N for Maryland)\n",
-    "    crs_epsg=32618,\n",
+    "    target_crs=32618,\n",
     "    \n",
     "    # NAIP bucket is requester-pays\n",
     "    requester_pays=True,\n",

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -139,7 +139,7 @@
     "    end = datetime(2022, 1, 1),\n",
     "\n",
     "    # Coordinate Reference System EPSG code for the output mosaic   \n",
-    "    crs_epsg = 3857,\n",
+    "    target_crs = 3857,\n",
     "\n",
     "    # The model recipe to be used for inference (CHM in this case)\n",
     "    model_recipe = ModelRecipes.META_CHM_V1\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -139,7 +139,7 @@
     "    end = datetime(2018, 1, 1),\n",
     "\n",
     "    # Coordinate Reference System EPSG code for the output mosaic   \n",
-    "    crs_epsg = 3857,\n",
+    "    target_crs = 3857,\n",
     "\n",
     "    # The model recipe to be used for inference (ChesapeakeRSC in this case)\n",
     "    model_recipe = ModelRecipes.CHESAPEAKE_RSC\n",

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -152,7 +152,7 @@
     "    end = datetime(2024, 1, 1),\n",
     "\n",
     "    # Coordinate Reference System EPSG code for the output mosaic   \n",
-    "    crs_epsg = 3857,\n",
+    "    target_crs = 3857,\n",
     "\n",
     "    # The model recipe to be used for inference (FTW in this case)\n",
     "    model_recipe = ModelRecipes.FTW,\n",

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -141,7 +141,7 @@
     "    end=datetime(2025, 1, 1),\n",
     "    \n",
     "    # Output CRS (Web Mercator)\n",
-    "    crs_epsg=3857,\n",
+    "    target_crs=3857,\n",
     ")\n",
     "\n",
     "mosaic_index.mosaics"
@@ -227,7 +227,7 @@
     "    end=datetime(2024, 9, 1),\n",
     "    \n",
     "    # Output CRS (Web Mercator)\n",
-    "    crs_epsg=3857,\n",
+    "    target_crs=3857,\n",
     ")\n",
     "\n",
     "all_bands_store = all_bands_index.first_row_mosaic\n",

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -127,7 +127,7 @@
     "    end=datetime(2024, 1, 1),\n",
     "\n",
     "    # Coordinate Reference System EPSG code for the output\n",
-    "    crs_epsg=3857,\n",
+    "    target_crs=3857,\n",
     "\n",
     "    # The model recipe and text prompt for object detection\n",
     "    model_recipe=GeometryModelRecipes.SAM3_TEXT_BBOX,\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -145,7 +145,7 @@
     "    end = datetime(2024, 1, 1),\n",
     "\n",
     "    # Coordinate Reference System EPSG code for the output mosaic   \n",
-    "    crs_epsg = 3857,\n",
+    "    target_crs = 3857,\n",
     "\n",
     "    # The model recipe to be used for inference (Tile2Net in this case)\n",
     "    model_recipe = ModelRecipes.TILE_2_NET,\n",


### PR DESCRIPTION
Update RasterFlow notebook examples to use the current `rasterflow-remote` SDK CRS keyword, `target_crs`, instead of the deprecated `crs_epsg` argument.

<details>
<summary>Codex context</summary>

### What changed

- Updated `build_mosaics`, `build_gti_mosaics`, `predict_mosaic_recipe`, and `predict_mosaic_geometries_recipe` notebook calls that passed a CRS keyword.
- Included the BYOM notebook's fenced `build_gti_mosaics` example after manual inspection, since that call lives in a markdown cell rather than an executable Python cell.
- Preserved notebook outputs and metadata; the diff is limited to keyword argument renames.

### Validation

- `python3` JSON parse check across all `Analyzing_Data/RasterFlow*.ipynb` notebooks.
- Custom static notebook scan over executable code cells and fenced Python snippets for RasterFlow SDK calls, confirming no `crs_epsg` keywords remain and CRS-bearing calls use `target_crs`.
- `uvx pre-commit run --files Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb Analyzing_Data/RasterFlow_CHM.ipynb Analyzing_Data/RasterFlow_Chesapeake.ipynb Analyzing_Data/RasterFlow_FTW.ipynb Analyzing_Data/RasterFlow_S2_Mosaic.ipynb Analyzing_Data/RasterFlow_SAM3.ipynb Analyzing_Data/RasterFlow_Tile2Net.ipynb`
- `git diff --check`

</details>
