### PR TITLE
fix: update RasterFlow Remote notebooks for result API

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -455,7 +455,7 @@
     "        nodata= 0.0,\n",
     ")\n",
     "mosaic_store = mosaic_index.first_row_mosaic\n",
-    "mosaic_index.mosaics\n",
+    "mosaic_index.mosaic_index_gdf\n",
     "```"
    ]
   },
@@ -538,7 +538,7 @@
     "        **asdict(custom_inference_config)\n",
     ")\n",
     "\n",
-    "predict_mosaic_output.mosaics\n",
+    "predict_mosaic_output.mosaic_index_gdf\n",
     "```"
    ]
   },

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -437,7 +437,7 @@
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "mosaic_store = mosaic_index.first_row_mosaic\n",
     "\n",
-    "print(f\"Mosaic index URI: {mosaic_index.uri}\")\n",
+    "print(f\"Mosaic index URI: {mosaic_index.mosaic_index_uri}\")\n",
     "print(f\"Mosaic store URI: {mosaic_store}\")"
    ]
   },
@@ -502,7 +502,7 @@
     "# # ChesapeakeRSC model - direct URL (no HuggingFace auth required)\n",
     "# MODEL_PATH = \"https://huggingface.co/wherobots/chesapeakersc-pt2/resolve/main/chesapeakersc-ep.pt2\"\n",
     "# \n",
-    "# prediction_store = client.predict_mosaic(\n",
+    "# prediction_index = client.predict_mosaic(\n",
     "#     mosaics=mosaic_store,\n",
     "#     model_path=MODEL_PATH,\n",
     "#     patch_size=512,\n",
@@ -515,7 +515,7 @@
     "#     merge_mode=MergeModeEnum.WEIGHTED_AVERAGE,\n",
     "# )\n",
     "# \n",
-    "# print(f\"Prediction index URI: {prediction_store.uri}\")"
+    "# print(f\"Prediction index URI: {prediction_index.mosaic_index_uri}\")"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -145,7 +145,7 @@
     "    model_recipe = ModelRecipes.META_CHM_V1\n",
     ")\n",
     "\n",
-    "model_output_index.mosaics"
+    "model_output_index.mosaic_index_gdf"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -134,7 +134,7 @@
     "    end=datetime(2025, 1, 1),\n",
     ")\n",
     "\n",
-    "mosaic_index.mosaics"
+    "mosaic_index.mosaic_index_gdf"
    ]
   },
   {
@@ -264,7 +264,7 @@
     "    xy_block_multiplier=1\n",
     ")\n",
     "\n",
-    "model_output_index.mosaics"
+    "model_output_index.mosaic_index_gdf"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -145,7 +145,7 @@
     "    model_recipe = ModelRecipes.CHESAPEAKE_RSC\n",
     ")\n",
     "\n",
-    "model_output_index.mosaics"
+    "model_output_index.mosaic_index_gdf"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -158,7 +158,7 @@
     "    model_recipe = ModelRecipes.FTW,\n",
     ")\n",
     "\n",
-    "model_output_index.mosaics"
+    "model_output_index.mosaic_index_gdf"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -144,7 +144,7 @@
     "    target_crs=3857,\n",
     ")\n",
     "\n",
-    "mosaic_index.mosaics"
+    "mosaic_index.mosaic_index_gdf"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -151,7 +151,7 @@
     "    model_recipe = ModelRecipes.TILE_2_NET,\n",
     ")\n",
     "\n",
-    "model_output_index.mosaics"
+    "model_output_index.mosaic_index_gdf"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- Update RasterFlow Remote notebook examples from the removed `.mosaics` alias to `mosaic_index_gdf`.
- Update mosaic result URI examples to use `mosaic_index_uri`.
- Keep local GeoDataFrame AOI examples user-facing clean and rely on the client to handle staging.

## Validation

- `python3` notebook JSON/static assertion: parsed 8 changed notebooks and checked no stale `.mosaics`, `mosaic_index.uri`, or `prediction_store.uri` references remain.
- `rg -n "\.mosaics\b|mosaic_index\.uri|prediction_store\.uri" .` returned no matches.
- `git diff --check`
- Commit hooks: `update-repo-structure` and `nb-clean` passed.
