### PR TITLE
fix(AI-126): migrate RasterFlow BYOR NAIP notebook off leafmap

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -52,9 +52,7 @@
     "import os\n",
     "\n",
     "import geopandas as gpd\n",
-    "import wkls\n",
-    "from ipyleaflet import basemaps\n",
-    "from leafmap import Map"
+    "import wkls"
    ]
   },
   {
@@ -78,19 +76,22 @@
     "print(f\"Bounding box: {gdf.total_bounds}\")\n",
     "print(f\"CRS: {gdf.crs}\")\n",
     "\n",
-    "# Display the AOI boundary on an interactive map with basemap\n",
+    "# Display the AOI boundary on the Wherobots-GL map\n",
     "minx, miny, maxx, maxy = gdf.total_bounds\n",
     "center_lat = (miny + maxy) / 2\n",
     "center_lon = (minx + maxx) / 2\n",
     "\n",
-    "m = Map(center=(center_lat, center_lon), zoom=10, basemap=basemaps.Esri.WorldImagery)\n",
-    "m.add_gdf(\n",
-    "    gdf, \n",
-    "    layer_name=\"Montgomery County, MD\", \n",
-    "    zoom_to_layer=True,\n",
-    "    style={\"color\": \"red\", \"fillColor\": \"lightblue\", \"fillOpacity\": 0.3, \"weight\": 2}\n",
-    ")\n",
-    "m"
+    "from wherobots_gl import Map\n",
+    "\n",
+    "# Wherobots-GL Map is URL-based, so write the AOI to GeoParquet first\n",
+    "aoi_path = os.getenv(\"USER_S3_PATH\") + \"montgomery_county_aoi.parquet\"\n",
+    "gdf.to_parquet(aoi_path)\n",
+    "\n",
+    "Map(\n",
+    "    layers=[{\"type\": \"geoparquet\", \"source\": aoi_path, \"name\": \"Montgomery County, MD\"}],\n",
+    "    view={\"zoom\": 10, \"lat\": center_lat, \"lng\": center_lon},\n",
+    "    basemap=\"satellite\",\n",
+    ")"
    ]
   },
   {
@@ -356,32 +357,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Visualize the GTI footprints with the AOI boundary on an interactive map\n",
+    "# Visualize the GTI footprints with the AOI boundary on the Wherobots-GL map\n",
     "\n",
     "# Calculate center from the AOI\n",
     "minx, miny, maxx, maxy = gdf.total_bounds\n",
     "center_lat = (miny + maxy) / 2\n",
     "center_lon = (minx + maxx) / 2\n",
     "\n",
-    "m = Map(center=(center_lat, center_lon), zoom=10, basemap=basemaps.Esri.WorldImagery)\n",
-    "\n",
-    "# Add NAIP tile footprints\n",
-    "m.add_gdf(\n",
-    "    gti_verify, \n",
-    "    layer_name=\"NAIP Tile Footprints\", \n",
-    "    style={\"color\": \"blue\", \"fillColor\": \"lightblue\", \"fillOpacity\": 0.3, \"weight\": 1}\n",
-    ")\n",
-    "\n",
-    "# Add AOI boundary on top\n",
-    "m.add_gdf(\n",
-    "    gdf, \n",
-    "    layer_name=\"Montgomery County, MD\", \n",
-    "    zoom_to_layer=True,\n",
-    "    style={\"color\": \"red\", \"fillColor\": \"none\", \"fillOpacity\": 0, \"weight\": 3}\n",
-    ")\n",
+    "from wherobots_gl import Map\n",
     "\n",
     "print(f\"Showing {len(gti_verify)} NAIP tile footprints over Montgomery County, MD\")\n",
-    "m"
+    "\n",
+    "Map(\n",
+    "    layers=[\n",
+    "        {\"type\": \"geoparquet\", \"source\": gti_path, \"name\": \"NAIP Tile Footprints\"},\n",
+    "        {\"type\": \"geoparquet\", \"source\": aoi_path, \"name\": \"Montgomery County, MD\"},\n",
+    "    ],\n",
+    "    view={\"zoom\": 10, \"lat\": center_lat, \"lng\": center_lon},\n",
+    "    basemap=\"satellite\",\n",
+    ")"
    ]
   },
   {
@@ -437,7 +431,7 @@
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "mosaic_store = mosaic_index.first_row_mosaic\n",
     "\n",
-    "print(f\"Mosaic index URI: {mosaic_index.mosaic_index_uri}\")\n",
+    "print(f\"Mosaic index URI: {mosaic_index.uri}\")\n",
     "print(f\"Mosaic store URI: {mosaic_store}\")"
    ]
   },
@@ -502,7 +496,7 @@
     "# # ChesapeakeRSC model - direct URL (no HuggingFace auth required)\n",
     "# MODEL_PATH = \"https://huggingface.co/wherobots/chesapeakersc-pt2/resolve/main/chesapeakersc-ep.pt2\"\n",
     "# \n",
-    "# prediction_index = client.predict_mosaic(\n",
+    "# prediction_store = client.predict_mosaic(\n",
     "#     mosaics=mosaic_store,\n",
     "#     model_path=MODEL_PATH,\n",
     "#     patch_size=512,\n",
@@ -515,7 +509,7 @@
     "#     merge_mode=MergeModeEnum.WEIGHTED_AVERAGE,\n",
     "# )\n",
     "# \n",
-    "# print(f\"Prediction index URI: {prediction_index.mosaic_index_uri}\")"
+    "# print(f\"Prediction index URI: {prediction_store.uri}\")"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -52,7 +52,8 @@
     "import os\n",
     "\n",
     "import geopandas as gpd\n",
-    "import wkls"
+    "import wkls\n",
+    "from wherobots_gl import Map"
    ]
   },
   {
@@ -80,8 +81,6 @@
     "minx, miny, maxx, maxy = gdf.total_bounds\n",
     "center_lat = (miny + maxy) / 2\n",
     "center_lon = (minx + maxx) / 2\n",
-    "\n",
-    "from wherobots_gl import Map\n",
     "\n",
     "# Wherobots-GL Map is URL-based, so write the AOI to GeoParquet first\n",
     "aoi_path = os.getenv(\"USER_S3_PATH\") + \"montgomery_county_aoi.parquet\"\n",
@@ -363,8 +362,6 @@
     "minx, miny, maxx, maxy = gdf.total_bounds\n",
     "center_lat = (miny + maxy) / 2\n",
     "center_lon = (minx + maxx) / 2\n",
-    "\n",
-    "from wherobots_gl import Map\n",
     "\n",
     "print(f\"Showing {len(gti_verify)} NAIP tile footprints over Montgomery County, MD\")\n",
     "\n",

--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -442,7 +442,7 @@
    "source": [
     "## (Optional) Build an optimized Zarr for visualization\n",
     "\n",
-    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them interactively on [cloud.wherobots.com/map](https://cloud.wherobots.com/map), you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution. To explore them smoothly with the `wherobots_gl.Map()` widget, you can build an *optimized* multiscale Zarr. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) to the store so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in.\n",
     "\n",
     "This step is optional and can take a few minutes for large outputs, so the code below is commented out by default — uncomment it to run it."
    ]
@@ -464,7 +464,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the mosaic and inference outputs from this notebook using [cloud.wherobots.com/map](https://cloud.wherobots.com/map). Zarr, GeoParquet, and other geospatial data formats are supported, so you can inspect either the mosaic output or the road-probability output from the preceding workflow steps.\n"
+    "You can visualize the mosaic and inference outputs from this notebook inline with the `wherobots_gl.Map()` widget — it renders Zarr, GeoParquet, and COG directly in the notebook (as shown above for the AOI and tile footprints), so you can inspect either the mosaic output or the road-probability output without leaving the notebook."
    ]
   },
   {
@@ -516,7 +516,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also open the road-probability output from the preceding inference workflow using [cloud.wherobots.com/map](https://cloud.wherobots.com/map) if RasterFlow is enabled for your organization.\n"
+    "You can visualize the road-probability output from the inference workflow inline as well — point a `wherobots_gl.Map()` at the prediction Zarr store (e.g. `prediction_store.uri`), the same way we mapped the AOI and tile footprints above."
    ]
   }
  ],


### PR DESCRIPTION
Standalone, single-notebook fix pulled out of the larger examples migration ([#168](https://github.com/wherobots/wherobots-examples/pull/168)) so it can land on its own.

**`Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`** — replaces the `leafmap`/`ipyleaflet` `Map` (line 57 on main: `from leafmap import Map`) with the `wherobots_gl` `Map` widget: the AOI and NAIP tile footprints are written to GeoParquet and rendered from there (two map cells). No other notebooks touched.

Identical to this notebook's change in #168; raising it separately per request. (The async layer-load polish Phil noted on this notebook is tracked separately as AI-310 and isn't part of this PR.)