### PR TITLE
fix(AI-126): correct RasterFlow result references

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb
@@ -428,7 +428,7 @@
     "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
     "mosaic_store = mosaic_index.first_row_mosaic\n",
     "\n",
-    "print(f\"Mosaic index URI: {mosaic_index.uri}\")\n",
+    "print(f\"Mosaic index URI: {mosaic_index.mosaic_index_uri}\")\n",
     "print(f\"Mosaic store URI: {mosaic_store}\")"
    ]
   },
@@ -506,14 +506,14 @@
     "#     merge_mode=MergeModeEnum.WEIGHTED_AVERAGE,\n",
     "# )\n",
     "# \n",
-    "# print(f\"Prediction index URI: {prediction_store.uri}\")"
+    "# print(f\"Prediction index URI: {prediction_store.mosaic_index_uri}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can visualize the road-probability output from the inference workflow inline as well — point a `wherobots_gl.Map()` at the prediction Zarr store (e.g. `prediction_store.uri`), the same way we mapped the AOI and tile footprints above."
+    "You can visualize the road-probability output from the inference workflow inline as well — point a `wherobots_gl.Map()` at the prediction Zarr store (e.g. `prediction_store.first_row_mosaic`), the same way we mapped the AOI and tile footprints above."
    ]
   }
  ],


### PR DESCRIPTION
## What/Why

Correct stale RasterFlow result references in the BYOR NAIP notebook so it remains compatible with RasterFlow Remote 2.7.1. The notebook migration in AI-126 reintroduced `.uri` accesses on `MosaicResult`, which exposes `mosaic_index_uri` for the GeoParquet index and `first_row_mosaic` for the first output Zarr.

Related Linear issue: [AI-126](https://linear.app/wherobots/issue/AI-126/wherobots-examples-migrate-the-rasterflow-notebook-family-wbgl)

## How

- use `mosaic_index_uri` when displaying mosaic index locations
- use `first_row_mosaic` when describing the Zarr passed to `wherobots_gl.Map`

## Verified

- `uvx pre-commit run nb-clean --files Analyzing_Data/RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`
- parsed the notebook as JSON and asserted the corrected result properties
- `git diff --check`
