### PR TITLE
Add NAIP mosaic notebook using built-in NAIP datasets

### DIFF
--- a/.github/workflows/scripts/update_docs_navigation.py
+++ b/.github/workflows/scripts/update_docs_navigation.py
@@ -46,6 +46,7 @@ NOTEBOOK_LOCATIONS: dict[str, list[str]] = {
     "rasterflow-changedetection": ["RasterFlow"],
     "rasterflow-ftw": ["RasterFlow"],
     "rasterflow-s2-mosaic": ["RasterFlow"],
+    "rasterflow-naip-mosaic": ["RasterFlow"],
     "rasterflow-tile2net": ["RasterFlow"],
     "rasterflow-bring-your-own-rasters-naip": ["RasterFlow"],
     "rasterflow-bring-your-own-model": ["RasterFlow"],

--- a/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
@@ -90,11 +90,11 @@
    "source": [
     "## Preview: example mosaic\n",
     "\n",
-    "A pre-generated NAIP 30 cm mosaic over College Park is available in the Wherobots Cloud map viewer, so you can see the kind of output this section builds without waiting for the build to finish.\n",
+    "A pre-generated NAIP 30 cm optimized mosaic over College Park is available in the Wherobots Cloud map viewer, so you can see the kind of output this section builds without waiting for the build to finish.\n",
     "\n",
     "View the interactive map [here](https://viz.wherobots.com/?z=14.24&lat=38.99775&lng=-76.93743&l0.id=4b363cf8-20cf-464f-bbaf-820ae32d85de&l0.src=s3%3A%2F%2Fwherobots-examples%2Frasterflow%2Fmosaics%2Fcollegepark_optimized.zarr&l0.name=NAIP+30+cm+College+Park+MD&l0.clim=24.672528253600106%2C200.6443167352033&l0.mode=rgb&l0.rgb=r%2Cg%2Cb%2Cband&l0.var=variables&title=NAIP+30+cm+College+Park+MD).\n",
     "\n",
-    "> **Note:** NAIP mosaics are **4-band** (red, green, blue, and near-infrared) — this preview renders only the RGB bands, but the NIR band is present in the store for indices like NDVI or false-color views. This pre-generated sample was built via the GTI approach (see `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`) with its bands labeled `r` / `g` / `b` / `ir`; a mosaic you build with the built-in `NAIP_30CM` dataset labels them `red` / `green` / `blue` / `nir` instead."
+    "> **Note:** NAIP mosaics are **4-band** (red, green, blue, and near-infrared) — this preview renders only the RGB bands, but the NIR band is present in the store for indices like NDVI or false-color views. This pre-generated sample was built via the GTI approach (see `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`) with its bands labeled `r` / `g` / `b` / `ir`; a mosaic you build with the built-in `NAIP_30CM` dataset labels them `naip_30cm:red` / `naip_30cm:green` / `naip_30cm:blue` / `naip_30cm:nir` instead."
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
@@ -1,0 +1,352 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b5dbc8f6",
+   "metadata": {},
+   "source": [
+    "# Building NAIP mosaics with RasterFlow\n",
+    "\n",
+    "This notebook demonstrates how to generate high-resolution aerial mosaics from the National Agriculture Imagery Program (NAIP) using Wherobots RasterFlow's built-in NAIP datasets. You will learn how to define an Area of Interest, build a NAIP composite mosaic, and visualize the results as RGB imagery.\n",
+    "\n",
+    "It mirrors the Sentinel-2 mosaic notebook (`RasterFlow_S2_Mosaic.ipynb`), but swaps satellite imagery for NAIP's sub-meter aerial imagery."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4dfba41",
+   "metadata": {},
+   "source": [
+    "### Built-in NAIP datasets\n",
+    "\n",
+    "RasterFlow ships two built-in NAIP configurations, selectable through `DatasetEnum`. Both provide four bands — red, green, blue, and near-infrared — as 8-bit (`Byte`) values:\n",
+    "\n",
+    "- **`NAIP_30CM`** — NAIP aerial imagery at **30 cm** resolution.\n",
+    "- **`NAIP_60CM`** — NAIP aerial imagery at **60 cm** resolution.\n",
+    "\n",
+    "A built-in mosaic's bands are labeled `<dataset>:<band>` — for example `naip_30cm:red`, `naip_30cm:green`, `naip_30cm:blue`, `naip_30cm:nir`.\n",
+    "\n",
+    "NAIP is flown state-by-state on a multi-year cycle, and the available resolution varies by state and year. RasterFlow selects imagery for the requested resolution and date window from its built-in NAIP index; if a location has no imagery at the requested resolution in that window, the mosaic will be empty. We use two AOIs below, each chosen because it has coverage at the target resolution:\n",
+    "\n",
+    "- **30 cm → College Park, MD** (2023) — the AOI from the Tile2Net notebook.\n",
+    "- **60 cm → Nashua, NH** (2021) — the AOI from the CHM notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bab3d9f",
+   "metadata": {},
+   "source": [
+    "## Setup and Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6dde3fa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "import wkls\n",
+    "from wherobots_gl import Map\n",
+    "from rasterflow_remote import RasterflowClient\n",
+    "from rasterflow_remote.data_models import DatasetEnum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5676f8f",
+   "metadata": {},
+   "source": [
+    "## Initializing the RasterFlow client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1dbdcd45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rf_client = RasterflowClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e33ecf2",
+   "metadata": {},
+   "source": [
+    "# 30 cm NAIP mosaic — College Park, MD\n",
+    "\n",
+    "We build a 30 cm NAIP mosaic over College Park, Maryland using the built-in `NAIP_30CM` dataset. College Park has 30 cm NAIP coverage in **2023**, so we use a date window covering that year. (This is the same AOI used in the Tile2Net notebook, `RasterFlow_Tile2Net.ipynb`.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ca431ff",
+   "metadata": {},
+   "source": [
+    "## Preview: example mosaic\n",
+    "\n",
+    "The map below shows a pre-generated NAIP mosaic over College Park, so you can see the kind of output this section builds without waiting for the build to finish.\n",
+    "\n",
+    "> **Note:** NAIP mosaics are **4-band** (red, green, blue, and near-infrared) — the map above renders only the RGB bands, but the NIR band is present in the store for indices like NDVI or false-color views. This pre-generated sample was built via the GTI approach (see `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`) with its bands labeled `r` / `g` / `b` / `ir`; a mosaic you build with the built-in `NAIP_30CM` dataset labels them `red` / `green` / `blue` / `nir` instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d85278f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map(\n",
+    "    layers=[\n",
+    "        {\n",
+    "            \"source\": \"s3://wherobots-examples/rasterflow/mosaics/collegepark_optimized.zarr\",\n",
+    "            \"name\": \"NAIP 30 cm mosaic (College Park, MD)\",\n",
+    "            \"variable\": \"variables\",\n",
+    "            \"renderMode\": \"rgb\",\n",
+    "            \"rgbBands\": {\"red\": \"r\", \"green\": \"g\", \"blue\": \"b\"},\n",
+    "            \"clim\": [24.67, 200.64],\n",
+    "        },\n",
+    "    ],\n",
+    "    view={\"lat\": 38.99775, \"lng\": -76.93743, \"zoom\": 14.24},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe9b3124",
+   "metadata": {},
+   "source": [
+    "## Selecting the Area of Interest (AOI)\n",
+    "\n",
+    "We use College Park, Maryland — an urban/suburban area in the Northeastern US with recent 30 cm NAIP coverage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96e009d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a geometry for College Park, MD using Well-Known Locations (https://github.com/wherobots/wkls)\n",
+    "collegepark_gdf = gpd.read_file(wkls.us.md.collegepark.geojson())\n",
+    "\n",
+    "min_lon, min_lat, max_lon, max_lat = collegepark_gdf.total_bounds\n",
+    "print(f\"Bounds: [{min_lon:.4f}, {min_lat:.4f}, {max_lon:.4f}, {max_lat:.4f}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45d49f70",
+   "metadata": {},
+   "source": [
+    "## Building the 30 cm mosaic\n",
+    "\n",
+    "This step builds a NAIP mosaic at 30 cm resolution using the built-in `NAIP_30CM` dataset. RasterFlow queries its built-in NAIP index for 30 cm imagery intersecting the AOI within the date window, reprojects/resamples into the target CRS, and mosaics the tiles into a Zarr store with red, green, blue, and NIR bands.\n",
+    "\n",
+    "> **Note:** This step can take several minutes to complete. If you already have a pre-built mosaic store, you can skip this build by assigning its URI directly in the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d507bce0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optionally skip the build by pointing at a pre-generated mosaic store:\n",
+    "# mosaic_store = \"s3://wherobots-examples/rasterflow/mosaics/collegepark_optimized.zarr\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a091935f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosaic_index = rf_client.build_mosaics(\n",
+    "    # Built-in NAIP 30 cm dataset (red, green, blue, nir)\n",
+    "    datasets=[DatasetEnum.NAIP_30CM],\n",
+    "\n",
+    "    # Area of Interest (AOI)\n",
+    "    aoi=collegepark_gdf,\n",
+    "\n",
+    "    # Acquisition window — College Park has 30 cm NAIP coverage in 2023\n",
+    "    start=datetime(2023, 1, 1),\n",
+    "    end=datetime(2024, 1, 1),\n",
+    "\n",
+    "    # Output CRS (Web Mercator)\n",
+    "    target_crs=3857,\n",
+    ")\n",
+    "\n",
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "mosaic_index.mosaic_index_gdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0619b68a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This example AOI has one geometry, so we select the first (only) mosaic location.\n",
+    "mosaic_store = mosaic_index.first_row_mosaic\n",
+    "\n",
+    "mosaic_store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ccd5b12",
+   "metadata": {},
+   "source": [
+    "## Build an optimized Zarr and visualize the output\n",
+    "\n",
+    "RasterFlow writes its outputs as Zarr stores at native resolution, which isn't ideal for interactive viewing — every pan or zoom would have to stream full-resolution pixels. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in. This typically takes a few minutes for large outputs.\n",
+    "\n",
+    "Once built, we can render it directly in this notebook with `wherobots_gl`. You can also open the full interactive experience at [cloud.wherobots.com/map](https://cloud.wherobots.com/map)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1c0d220",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimized_store = rf_client.build_zarr_multiscales(source_store=mosaic_store)\n",
+    "\n",
+    "# The built-in NAIP dataset labels its bands red / green / blue / nir.\n",
+    "# To control the RGB rendering explicitly, pass a layer dict with rgbBands as in the preview cell above.\n",
+    "Map(layers=[optimized_store.uri])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3cdaf16",
+   "metadata": {},
+   "source": [
+    "# 60 cm NAIP mosaic — Nashua, NH\n",
+    "\n",
+    "The `NAIP_60CM` dataset builds a mosaic from NAIP's 60 cm imagery. Pick 60 cm over 30 cm when:\n",
+    "\n",
+    "- You need coverage for a **year or location** that wasn't flown at 30 cm — 60 cm imagery is available for more states and more years.\n",
+    "- You're mosaicking a **large area** and want smaller outputs and faster builds — 60 cm imagery is roughly a quarter of the pixels of 30 cm.\n",
+    "\n",
+    "We build over Nashua, NH, which has a mix of urban, park, and forest cover. New Hampshire has 60 cm NAIP coverage in **2021**, so we use a date window covering that year. (This is the same AOI used in the CHM notebook, `RasterFlow_CHM.ipynb`.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "614658a1",
+   "metadata": {},
+   "source": [
+    "## Preview: example mosaic\n",
+    "\n",
+    "The map below shows a pre-generated 60 cm NAIP mosaic over Nashua, NH."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f5f10c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Map(\n",
+    "    layers=[\n",
+    "        {\n",
+    "            \"source\": \"s3://wherobots-examples/rasterflow/mosaics/nashua_optimized.zarr\",\n",
+    "            \"name\": \"NAIP 60 cm mosaic (Nashua, NH)\",\n",
+    "            \"variable\": \"variables\",\n",
+    "            \"renderMode\": \"rgb\",\n",
+    "            \"rgbBands\": {\"red\": \"red\", \"green\": \"green\", \"blue\": \"blue\"},\n",
+    "            \"clim\": [33.37, 201.81],\n",
+    "        },\n",
+    "    ],\n",
+    "    view={\"lat\": 42.7654, \"lng\": -71.4676, \"zoom\": 11},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ec60954",
+   "metadata": {},
+   "source": [
+    "## Selecting the AOI and building the mosaic\n",
+    "\n",
+    "We build the Nashua mosaic with `NAIP_60CM` the same way as the 30 cm mosaic above. As before, you can pass the resulting store to `build_zarr_multiscales` and render it with `wherobots_gl` to view your freshly built output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "689955b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a geometry for Nashua, NH using Well-Known Locations (https://github.com/wherobots/wkls)\n",
+    "nashua_gdf = gpd.read_file(wkls.us.nh.nashua.geojson())\n",
+    "\n",
+    "coarse_index = rf_client.build_mosaics(\n",
+    "    # Built-in NAIP 60 cm dataset (red, green, blue, nir)\n",
+    "    datasets=[DatasetEnum.NAIP_60CM],\n",
+    "\n",
+    "    # Area of Interest (AOI)\n",
+    "    aoi=nashua_gdf,\n",
+    "\n",
+    "    # Acquisition window — New Hampshire has 60 cm NAIP coverage in 2021\n",
+    "    start=datetime(2021, 1, 1),\n",
+    "    end=datetime(2022, 1, 1),\n",
+    "\n",
+    "    # Output CRS (Web Mercator)\n",
+    "    target_crs=3857,\n",
+    ")\n",
+    "\n",
+    "coarse_store = coarse_index.first_row_mosaic\n",
+    "print(f\"60 cm mosaic store: {coarse_store}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af758e4b",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated how to:\n",
+    "\n",
+    "1. Build a 30 cm NAIP aerial mosaic over College Park, MD with the built-in `DatasetEnum.NAIP_30CM` dataset\n",
+    "2. Optimize the Zarr store with overviews and render it inline with `wherobots_gl`\n",
+    "3. Build a 60 cm NAIP mosaic over Nashua, NH with `DatasetEnum.NAIP_60CM`\n",
+    "\n",
+    "### Next steps\n",
+    "\n",
+    "- Compare a NAIP mosaic with the Sentinel-2 mosaic over the same AOI (see `RasterFlow_S2_Mosaic.ipynb`)\n",
+    "- Run a model on the NAIP mosaic — for example sidewalk/road detection with Tile2Net on the College Park mosaic (`RasterFlow_Tile2Net.ipynb`) or tree canopy height with Meta CHM on the Nashua mosaic (`RasterFlow_CHM.ipynb`)\n",
+    "- Use the mosaic as input for **model inference** using [predict_mosaic](https://docs.wherobots.com/reference/rasterflow/client#predict_mosaic)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
@@ -140,7 +140,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Optionally skip the build by pointing at a pre-generated mosaic store:\n",
+    "# Optionally, you can skip running the build cell below and use this pre-generated mosaic store:\n",
     "# mosaic_store = \"s3://wherobots-examples/rasterflow/mosaics/collegepark_optimized.zarr\""
    ]
   },
@@ -243,7 +243,21 @@
    "source": [
     "## Selecting the AOI and building the mosaic\n",
     "\n",
-    "We build the Nashua mosaic with `NAIP_60CM` the same way as the 30 cm mosaic above. As before, you can pass the resulting store to `build_zarr_multiscales` and open its `map_url` in the Wherobots Cloud map viewer to view your freshly built output."
+    "We build the Nashua mosaic with `NAIP_60CM` the same way as the 30 cm mosaic above. As in the 30cm example above, you can pass the resulting store to `build_zarr_multiscales` and open its `map_url` in the Wherobots Cloud map viewer to view your freshly built output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bdc124c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a geometry for Nashua, NH using Well-Known Locations (https://github.com/wherobots/wkls)\n",
+    "nashua_gdf = gpd.read_file(wkls.us.nh.nashua.geojson())\n",
+    "\n",
+    "min_lon, min_lat, max_lon, max_lat = nashua_gdf.total_bounds\n",
+    "print(f\"Bounds: [{min_lon:.4f}, {min_lat:.4f}, {max_lon:.4f}, {max_lat:.4f}]\")"
    ]
   },
   {
@@ -253,9 +267,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Generate a geometry for Nashua, NH using Well-Known Locations (https://github.com/wherobots/wkls)\n",
-    "nashua_gdf = gpd.read_file(wkls.us.nh.nashua.geojson())\n",
-    "\n",
     "coarse_index = rf_client.build_mosaics(\n",
     "    # Built-in NAIP 60 cm dataset (red, green, blue, nir)\n",
     "    datasets=[DatasetEnum.NAIP_60CM],\n",
@@ -303,7 +314,15 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
@@ -243,7 +243,7 @@
    "source": [
     "## Selecting the AOI and building the mosaic\n",
     "\n",
-    "We build the Nashua mosaic with `NAIP_60CM` the same way as the 30 cm mosaic above. As in the 30cm example above, you can pass the resulting store to `build_zarr_multiscales` and open its `map_url` in the Wherobots Cloud map viewer to view your freshly built output."
+    "We build the Nashua mosaic with `NAIP_60CM` the same way as the 30 cm mosaic above. As in the 30cm example above, you can add an additional cell to pass the resulting store to `build_zarr_multiscales` and open its `map_url` in the Wherobots Cloud map viewer to view your freshly built output."
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "18c09bf1",
+   "id": "3f6971ff",
    "metadata": {},
    "source": [
     "# Building NAIP mosaics with RasterFlow\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "067de66b",
+   "id": "ba57454a",
    "metadata": {},
    "source": [
     "### Built-in NAIP datasets\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4fdde01b",
+   "id": "a985a6f9",
    "metadata": {},
    "source": [
     "## Setup and Imports"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a7428b2",
+   "id": "e6f557cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,14 +51,13 @@
     "\n",
     "import geopandas as gpd\n",
     "import wkls\n",
-    "from wherobots_gl import Map\n",
     "from rasterflow_remote import RasterflowClient\n",
     "from rasterflow_remote.data_models import DatasetEnum"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3dfa061f",
+   "id": "b059c91e",
    "metadata": {},
    "source": [
     "## Initializing the RasterFlow client"
@@ -67,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20bf167f",
+   "id": "2bc604f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +75,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30568d65",
+   "id": "af6e5416",
    "metadata": {},
    "source": [
     "# 30 cm NAIP mosaic — College Park, MD\n",
@@ -86,41 +85,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3428779",
+   "id": "113bf5ed",
    "metadata": {},
    "source": [
     "## Preview: example mosaic\n",
     "\n",
-    "The map below shows a pre-generated NAIP mosaic over College Park, so you can see the kind of output this section builds without waiting for the build to finish.\n",
+    "A pre-generated NAIP 30 cm mosaic over College Park is available in the Wherobots Cloud map viewer, so you can see the kind of output this section builds without waiting for the build to finish.\n",
     "\n",
-    "> **Note:** NAIP mosaics are **4-band** (red, green, blue, and near-infrared) — the map above renders only the RGB bands, but the NIR band is present in the store for indices like NDVI or false-color views. This pre-generated sample was built via the GTI approach (see `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`) with its bands labeled `r` / `g` / `b` / `ir`; a mosaic you build with the built-in `NAIP_30CM` dataset labels them `red` / `green` / `blue` / `nir` instead."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fdf79820",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Map(\n",
-    "    layers=[\n",
-    "        {\n",
-    "            \"source\": \"s3://wherobots-examples/rasterflow/mosaics/collegepark_optimized.zarr\",\n",
-    "            \"name\": \"NAIP 30 cm mosaic (College Park, MD)\",\n",
-    "            \"variable\": \"variables\",\n",
-    "            \"renderMode\": \"rgb\",\n",
-    "            \"rgbBands\": {\"red\": \"r\", \"green\": \"g\", \"blue\": \"b\"},\n",
-    "            \"clim\": [24.67, 200.64],\n",
-    "        },\n",
-    "    ],\n",
-    "    view={\"lat\": 38.99775, \"lng\": -76.93743, \"zoom\": 14.24},\n",
-    ")"
+    "View the interactive map [here](https://viz.wherobots.com/?z=14.24&lat=38.99775&lng=-76.93743&l0.id=4b363cf8-20cf-464f-bbaf-820ae32d85de&l0.src=s3%3A%2F%2Fwherobots-examples%2Frasterflow%2Fmosaics%2Fcollegepark_optimized.zarr&l0.name=NAIP+30+cm+College+Park+MD&l0.clim=24.672528253600106%2C200.6443167352033&l0.mode=rgb&l0.rgb=r%2Cg%2Cb%2Cband&l0.var=variables&title=NAIP+30+cm+College+Park+MD).\n",
+    "\n",
+    "> **Note:** NAIP mosaics are **4-band** (red, green, blue, and near-infrared) — this preview renders only the RGB bands, but the NIR band is present in the store for indices like NDVI or false-color views. This pre-generated sample was built via the GTI approach (see `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`) with its bands labeled `r` / `g` / `b` / `ir`; a mosaic you build with the built-in `NAIP_30CM` dataset labels them `red` / `green` / `blue` / `nir` instead."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d68755a9",
+   "id": "66e07d52",
    "metadata": {},
    "source": [
     "## Selecting the Area of Interest (AOI)\n",
@@ -131,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "836c5fa9",
+   "id": "a4cea6bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "291c73c6",
+   "id": "0cc359e5",
    "metadata": {},
    "source": [
     "## Building the 30 cm mosaic\n",
@@ -157,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40192095",
+   "id": "eb8579d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba25e79f",
+   "id": "cac9a4ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6df3e0ff",
+   "id": "0a4a7ee2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,33 +185,33 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a96d8738",
+   "id": "9dd97e28",
    "metadata": {},
    "source": [
     "## Build an optimized Zarr and visualize the output\n",
     "\n",
     "RasterFlow writes its outputs as Zarr stores at native resolution, which isn't ideal for interactive viewing — every pan or zoom would have to stream full-resolution pixels. `build_zarr_multiscales` adds downsampled overview levels (image pyramids) so the map can stream coarse tiles when zoomed out and full-resolution pixels when zoomed in. This typically takes a few minutes for large outputs.\n",
     "\n",
-    "Once built, we can render it directly in this notebook with `wherobots_gl`. You can also open the full interactive experience at [cloud.wherobots.com/map](https://cloud.wherobots.com/map)."
+    "Once built, open it in the Wherobots Cloud map viewer via the store's `map_url`. (`build_zarr_multiscales` returns a `UriOutput`, whose `map_url` property links to the map viewer for that store.)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b6ea076",
+   "id": "81697b28",
    "metadata": {},
    "outputs": [],
    "source": [
     "optimized_store = rf_client.build_zarr_multiscales(source_store=mosaic_store)\n",
     "\n",
-    "# The built-in NAIP dataset labels its bands red / green / blue / nir.\n",
-    "# To control the RGB rendering explicitly, pass a layer dict with rgbBands as in the preview cell above.\n",
-    "Map(layers=[optimized_store.uri])"
+    "print(f\"Optimized store: {optimized_store.uri}\")\n",
+    "# Open the freshly built mosaic in the Wherobots Cloud map viewer:\n",
+    "print(f\"View on the map: {optimized_store.map_url}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "42f7e6a7",
+   "id": "44b71069",
    "metadata": {},
    "source": [
     "# 60 cm NAIP mosaic — Nashua, NH\n",
@@ -247,50 +226,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0808074b",
+   "id": "a4dd02b7",
    "metadata": {},
    "source": [
     "## Preview: example mosaic\n",
     "\n",
-    "The map below shows a pre-generated 60 cm NAIP mosaic over Nashua, NH."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "69d3f92f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Map(\n",
-    "    layers=[\n",
-    "        {\n",
-    "            \"source\": \"s3://wherobots-examples/rasterflow/mosaics/nashua_optimized.zarr\",\n",
-    "            \"name\": \"NAIP 60 cm mosaic (Nashua, NH)\",\n",
-    "            \"variable\": \"variables\",\n",
-    "            \"renderMode\": \"rgb\",\n",
-    "            \"rgbBands\": {\"red\": \"red\", \"green\": \"green\", \"blue\": \"blue\"},\n",
-    "            \"clim\": [33.37, 201.81],\n",
-    "        },\n",
-    "    ],\n",
-    "    view={\"lat\": 42.7654, \"lng\": -71.4676, \"zoom\": 11},\n",
-    ")"
+    "A pre-generated 60 cm NAIP mosaic over Nashua, NH is available in the Wherobots Cloud map viewer.\n",
+    "\n",
+    "View the interactive map [here](https://viz.wherobots.com/?z=11&lat=42.7654&lng=-71.4676&l0.id=4a8d3619-291c-4acb-8246-99aea96c3bc4&l0.src=s3%3A%2F%2Fwherobots-examples%2Frasterflow%2Fmosaics%2Fnashua_optimized.zarr&l0.name=NAIP+60+cm+Nashua+NH&l0.clim=33.370882202482704%2C201.81320110343603&l0.mode=rgb&l0.rgb=red%2Cgreen%2Cblue%2Cband&l0.var=variables&title=NAIP+60+cm+Nashua+NH)."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "badfa956",
+   "id": "632f4ef4",
    "metadata": {},
    "source": [
     "## Selecting the AOI and building the mosaic\n",
     "\n",
-    "We build the Nashua mosaic with `NAIP_60CM` the same way as the 30 cm mosaic above. As before, you can pass the resulting store to `build_zarr_multiscales` and render it with `wherobots_gl` to view your freshly built output."
+    "We build the Nashua mosaic with `NAIP_60CM` the same way as the 30 cm mosaic above. As before, you can pass the resulting store to `build_zarr_multiscales` and open its `map_url` in the Wherobots Cloud map viewer to view your freshly built output."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63c678c8",
+   "id": "6b56db5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b5a96bc",
+   "id": "0c81fb99",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -326,7 +285,7 @@
     "This notebook demonstrated how to:\n",
     "\n",
     "1. Build a 30 cm NAIP aerial mosaic over College Park, MD with the built-in `DatasetEnum.NAIP_30CM` dataset\n",
-    "2. Optimize the Zarr store with overviews and render it inline with `wherobots_gl`\n",
+    "2. Optimize the Zarr store with overviews and open it in the Wherobots Cloud map viewer\n",
     "3. Build a 60 cm NAIP mosaic over Nashua, NH with `DatasetEnum.NAIP_60CM`\n",
     "\n",
     "### Next steps\n",

--- a/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b5dbc8f6",
+   "id": "18c09bf1",
    "metadata": {},
    "source": [
     "# Building NAIP mosaics with RasterFlow\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4dfba41",
+   "id": "067de66b",
    "metadata": {},
    "source": [
     "### Built-in NAIP datasets\n",
@@ -28,13 +28,13 @@
     "\n",
     "NAIP is flown state-by-state on a multi-year cycle, and the available resolution varies by state and year. RasterFlow selects imagery for the requested resolution and date window from its built-in NAIP index; if a location has no imagery at the requested resolution in that window, the mosaic will be empty. We use two AOIs below, each chosen because it has coverage at the target resolution:\n",
     "\n",
-    "- **30 cm → College Park, MD** (2023) — the AOI from the Tile2Net notebook.\n",
+    "- **30 cm → College Park, MD** (2023) — the AOI from the SAM3 notebook.\n",
     "- **60 cm → Nashua, NH** (2021) — the AOI from the CHM notebook."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1bab3d9f",
+   "id": "4fdde01b",
    "metadata": {},
    "source": [
     "## Setup and Imports"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6dde3fa2",
+   "id": "6a7428b2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5676f8f",
+   "id": "3dfa061f",
    "metadata": {},
    "source": [
     "## Initializing the RasterFlow client"
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dbdcd45",
+   "id": "20bf167f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,17 +76,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e33ecf2",
+   "id": "30568d65",
    "metadata": {},
    "source": [
     "# 30 cm NAIP mosaic — College Park, MD\n",
     "\n",
-    "We build a 30 cm NAIP mosaic over College Park, Maryland using the built-in `NAIP_30CM` dataset. College Park has 30 cm NAIP coverage in **2023**, so we use a date window covering that year. (This is the same AOI used in the Tile2Net notebook, `RasterFlow_Tile2Net.ipynb`.)"
+    "We build a 30 cm NAIP mosaic over College Park, Maryland using the built-in `NAIP_30CM` dataset. College Park has 30 cm NAIP coverage in **2023**, so we use a date window covering that year. (This is the same AOI used in the SAM3 notebook, `RasterFlow_SAM3.ipynb`.)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2ca431ff",
+   "id": "f3428779",
    "metadata": {},
    "source": [
     "## Preview: example mosaic\n",
@@ -99,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d85278f",
+   "id": "fdf79820",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe9b3124",
+   "id": "d68755a9",
    "metadata": {},
    "source": [
     "## Selecting the Area of Interest (AOI)\n",
@@ -131,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96e009d9",
+   "id": "836c5fa9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45d49f70",
+   "id": "291c73c6",
    "metadata": {},
    "source": [
     "## Building the 30 cm mosaic\n",
@@ -157,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d507bce0",
+   "id": "40192095",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a091935f",
+   "id": "ba25e79f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0619b68a",
+   "id": "6df3e0ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ccd5b12",
+   "id": "a96d8738",
    "metadata": {},
    "source": [
     "## Build an optimized Zarr and visualize the output\n",
@@ -219,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1c0d220",
+   "id": "5b6ea076",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3cdaf16",
+   "id": "42f7e6a7",
    "metadata": {},
    "source": [
     "# 60 cm NAIP mosaic — Nashua, NH\n",
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "614658a1",
+   "id": "0808074b",
    "metadata": {},
    "source": [
     "## Preview: example mosaic\n",
@@ -258,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f5f10c6",
+   "id": "69d3f92f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ec60954",
+   "id": "badfa956",
    "metadata": {},
    "source": [
     "## Selecting the AOI and building the mosaic\n",
@@ -290,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "689955b1",
+   "id": "63c678c8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af758e4b",
+   "id": "2b5a96bc",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -332,7 +332,7 @@
     "### Next steps\n",
     "\n",
     "- Compare a NAIP mosaic with the Sentinel-2 mosaic over the same AOI (see `RasterFlow_S2_Mosaic.ipynb`)\n",
-    "- Run a model on the NAIP mosaic — for example sidewalk/road detection with Tile2Net on the College Park mosaic (`RasterFlow_Tile2Net.ipynb`) or tree canopy height with Meta CHM on the Nashua mosaic (`RasterFlow_CHM.ipynb`)\n",
+    "- Run a model on the NAIP mosaic — for example text-prompted object detection with SAM3 on the College Park mosaic (`RasterFlow_SAM3.ipynb`) or tree canopy height with Meta CHM on the Nashua mosaic (`RasterFlow_CHM.ipynb`)\n",
     "- Use the mosaic as input for **model inference** using [predict_mosaic](https://docs.wherobots.com/reference/rasterflow/client#predict_mosaic)"
    ]
   }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines, pre-commit s
 |   |-- RasterFlow_ChangeDetection.ipynb
 |   |-- RasterFlow_Chesapeake.ipynb
 |   |-- RasterFlow_FTW.ipynb
+|   |-- RasterFlow_NAIP_Mosaic.ipynb
 |   |-- RasterFlow_S2_Mosaic.ipynb
 |   |-- RasterFlow_SAM3.ipynb
 |   |-- RasterFlow_Tile2Net.ipynb


### PR DESCRIPTION
## Summary

Adds `Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb`, a NAIP counterpart to `RasterFlow_S2_Mosaic.ipynb`. It builds NAIP mosaics using the **built-in NAIP datasets** (`DatasetEnum.NAIP_30CM` / `NAIP_60CM`) via `build_mosaics`, rather than hand-building a GTI index (as in `RasterFlow_Bring_Your_Own_Rasters_NAIP.ipynb`).

## What it covers

- **30 cm mosaic → College Park, MD (2023)** — same AOI as the Tile2Net notebook
- **60 cm mosaic → Nashua, NH (2021)** — same AOI as the CHM notebook

Both AOIs were checked against the built-in NAIP index (`s3://wherobots-examples/rasterflow/indexes/naip_index.parquet`) to confirm coverage at the target resolution. Each section previews an existing pre-generated sample mosaic (`collegepark_optimized.zarr`, `nashua_optimized.zarr`) so the notebook renders immediately, then shows the full `build_mosaics` → `build_zarr_multiscales` → render flow.

## Notes

- Built-in NAIP datasets emit 4 bands (`red/green/blue/nir`); the notebook documents the band-label difference vs. the GTI path's `r/g/b/ir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)