### PR TITLE
fix: Update update_docs_navigation.py to properly categorize notebook

### DIFF
--- a/.github/workflows/scripts/update_docs_navigation.py
+++ b/.github/workflows/scripts/update_docs_navigation.py
@@ -52,6 +52,7 @@ NOTEBOOK_LOCATIONS: dict[str, list[str]] = {
     "rasterflow-bring-your-own-model": ["RasterFlow"],
     # Advanced Topics group (top-level)
     "isochrones": ["Advanced Topics"],
+    "california-coastal-flood-risk-analysis": ["Advanced Topics"],
     "zonal-stats-esaworldcover-texas": ["Advanced Topics"],
     "loading-common-spatial-file-types": ["Advanced Topics"],
     "map-tile-generation": ["Advanced Topics"],


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

## Checklist

- [ ] I have tested these changes in Wherobots Cloud
- [ ] Notebooks follow the [style guide](../CONTRIBUTING.md#style-guide)

---

## For Release PRs (Wherobots Team Only)

If this PR is part of a wbc-images release, tags must be created after merging:

- [ ] I will create tags from `main` after merge (or tags are not needed for this PR)

**Tagging instructions:** Both v1 and v2 tags should typically point to the same commit unless you know otherwise.

```bash
git checkout main && git pull
git tag v1.X.Y && git tag v2.X.Y-preview
git push origin v1.X.Y v2.X.Y-preview
```

See [CONTRIBUTING.md](../CONTRIBUTING.md#wherobots-contributions) for details.
