### PR TITLE
Remove swimming pool references from the SAM3 notebook

### DIFF
--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -202,7 +202,7 @@
     "    # The model recipe and text prompt for object detection\n",
     "    model_recipe=GeometryModelRecipes.SAM3_TEXT_GEOMETRY,\n",
     "    # You can also pass multiple prompts to detect several object types at once,\n",
-    "    # e.g. text_prompt=[\"roofs\", \"solar panels\"]\n",
+    "    # e.g. text_prompt=[\"roofs\", \"roads\"]\n",
     "    text_prompt=\"roofs\",\n",
     "    # Lower confidence thresholds surface more (but noisier) detections; you may\n",
     "    # want to adjust this to trade off recall against precision for your AOI.\n",

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -42,7 +42,7 @@
     "- *SAM3 input mosaic*: RGB NAIP aerial imagery the model runs on\n",
     "- *SAM3 PM Tiles*: polygons output directly by the text-prompted model, delivered as PMTiles for fast rendering at scale (SAM3 is a geometry inference model, so there is no intermediate raster output)\n",
     "\n",
-    "View the interactive map [here](https://viz.wherobots.com/?z=9.61&lat=44.98530&lng=-122.47688&l0.id=3930c361-98e6-4b7a-a534-ef69709881a7&l0.src=s3%3A%2F%2Fwherobots-examples%2Frasterflow%2Fmosaics%2Fmarion_county_optimized.zarr&l0.name=SAM3+input+mosaic&l0.clim=35.23256150636151%2C187.34808753310205&l0.mode=rgb&l0.rgb=red%2Cgreen%2Cblue%2Cband&l0.ndvi=nir%2Cred%2Cband&l0.var=variables&l1.id=4c8693bf-6375-4e97-887c-6c08b7e4d10b&l1.src=s3%3A%2F%2Fwherobots-examples%2Frasterflow%2Fmodel-outputs%2Fmarion_county_sam3.pmtiles&l1.name=SAM3+PM+Tiles&l1.type=pmtiles&l1.lw=2&l1.cr=5&title=SAM3+Marion+County+OR)."
+    "View the interactive map [here](https://viz.wherobots.com/?z=9.61&lat=44.98530&lng=-122.47688&l0.id=3930c361-98e6-4b7a-a534-ef69709881a7&l0.src=s3%3A%2F%2Fwherobots-examples%2Frasterflow%2Fmosaics%2Fmarion_county_optimized.zarr&l0.name=SAM3+input+mosaic&l0.clim=35.23256150636151%2C187.34808753310205&l0.mode=rgb&l0.rgb=red%2Cgreen%2Cblue%2Cband&l0.ndvi=nir%2Cred%2Cband&l0.var=variables&l1.id=4c8693bf-6375-4e97-887c-6c08b7e4d10b&l1.src=s3%3A%2F%2Fwherobots-examples%2Frasterflow%2Fmodel-outputs%2Fmarion_county_sam3.pmtiles&l1.name=SAM3+PM+Tiles&l1.type=pmtiles&l1.lw=2&l1.cr=5&l1.sl.swimming+pools.vis=0&title=SAM3+Marion+County+OR)."
    ]
   },
   {
@@ -202,7 +202,7 @@
     "    # The model recipe and text prompt for object detection\n",
     "    model_recipe=GeometryModelRecipes.SAM3_TEXT_GEOMETRY,\n",
     "    # You can also pass multiple prompts to detect several object types at once,\n",
-    "    # e.g. text_prompt=[\"roofs\", \"swimming pools\"]\n",
+    "    # e.g. text_prompt=[\"roofs\", \"solar panels\"]\n",
     "    text_prompt=\"roofs\",\n",
     "    # Lower confidence thresholds surface more (but noisier) detections; you may\n",
     "    # want to adjust this to trade off recall against precision for your AOI.\n",


### PR DESCRIPTION
Removes the swimming pool references from `Analyzing_Data/RasterFlow_SAM3.ipynb` so the walkthrough stays focused on roof inspection:

- Adds `l1.sl.swimming+pools.vis=0` to the shared viz.wherobots.com map link, so the swimming pools layer in the PMTiles output is hidden when a reader opens the map.
- Uses `["roofs", "roads"]` instead of `["roofs", "swimming pools"]` in the multi-prompt example comment.