### PR TITLE
Remove Private Preview comments from RasterFlow notebooks

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -466,7 +466,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "You can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -256,7 +256,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "You can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -368,7 +368,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "You can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -256,7 +256,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "You can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -204,7 +204,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "You can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -190,7 +190,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "You can visualize the Zarr outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -261,7 +261,7 @@
    "source": [
     "## Visualizing outputs\n",
     "\n",
-    "If RasterFlow is enabled for your organization, you can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
+    "You can visualize the Zarr, GeoParquet, and other geospatial outputs using [cloud.wherobots.com/map](https://cloud.wherobots.com/map).\n"
    ]
   },
   {


### PR DESCRIPTION
## Description

RasterFlow is no longer in Private Preview, but the sample notebooks still condition on whether it is enabled for the reader. This removes the gating language and assumes readers can run RasterFlow.

In seven RasterFlow notebooks: `If RasterFlow is enabled for your organization, you can visualize the ... outputs using cloud.wherobots.com/map` → `You can visualize the ... outputs using cloud.wherobots.com/map`. Affects `RasterFlow_CHM`, `RasterFlow_Chesapeake`, `RasterFlow_ChangeDetection`, `RasterFlow_FTW`, `RasterFlow_Tile2Net`, `RasterFlow_S2_Mosaic`, `RasterFlow_Bring_Your_Own_Model`.

Notebook changes only. The `<Badge color="purple">Private Preview</Badge>` that `notebook_to_mdx.py` stamps on published RasterFlow docs pages is **not** touched here — that is handled separately.

Aside from that badge, no other "Private Preview" / preview-gating wording remains in the repo (the remaining "preview" hits are the docs local-preview workflow, the read-only-notebook Tip callout, and `## Preview: model inputs and outputs` section headings, which are unrelated).

Linear: [AI-429](https://linear.app/wherobots/issue/AI-429/private-preview-commentary-exists-in-the-sample-notebooks)

## Checklist

- [ ] I have tested these changes in Wherobots Cloud
- [x] Notebooks follow the [style guide](../CONTRIBUTING.md#style-guide)

Text-only changes; no cells were re-executed and no outputs changed.

---

## For Release PRs (Wherobots Team Only)

- [x] I will create tags from `main` after merge (or tags are not needed for this PR)