### PR TITLE
Label RasterFlow notebook pages as Public Preview

### DIFF
--- a/.github/workflows/scripts/notebook_to_mdx.py
+++ b/.github/workflows/scripts/notebook_to_mdx.py
@@ -405,9 +405,9 @@ def convert_notebook_to_mdx(
     mdx_parts.append("---")
     mdx_parts.append("")
 
-    # Add Private Preview badge for RasterFlow notebooks only
+    # Add Public Preview badge for RasterFlow notebooks only
     if is_rasterflow:
-        mdx_parts.append('<Badge color="purple">Private Preview</Badge>')
+        mdx_parts.append('<Badge color="purple">Public Preview</Badge>')
         mdx_parts.append("")
 
     # Add Tip callout about running the notebook interactively


### PR DESCRIPTION
RasterFlow is no longer gated, but the MDX converter still injected a `Private Preview` badge into every generated RasterFlow tutorial page.

#192 fixed the prose *inside* the notebooks. The badge is injected by `notebook_to_mdx.py`, so it was untouched — which is why the published tutorials still read "Private Preview".

## Change

One line in `.github/workflows/scripts/notebook_to_mdx.py`:

```diff
-    mdx_parts.append('<Badge color="purple">Private Preview</Badge>')
+    mdx_parts.append('<Badge color="purple">Public Preview</Badge>')
```

## Effect

Regenerates the ten `tutorials/example-notebooks/rasterflow-*.mdx` pages in `wherobots/docs`, bringing them in line with `reference/rasterflow/*.mdx`, which flipped in wherobots/docs#441.

`convert-notebooks.yml` already lists this script in its `paths:` filter, so merging fires the sync automatically — no notebook edits needed. It opens a follow-up PR on `wherobots/docs` that also needs merging before the pages go live.

## Verification

Ran the converter against `Analyzing_Data/` and diffed all ten generated pages against `wherobots/docs` main. The badge line is the only difference in every file — no incidental churn.

## Note

This covers the auto-generated tutorials only. The hand-written pages (`develop/rasterflow/`, `tutorials/index.mdx`, `get-started/wherobots-fundamentals/platform-overview.mdx`, and `snippets/_rasterflow-private-preview-callout.mdx`) still say Private Preview and need a separate PR on `wherobots/docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)