### PR TITLE
docs: label the SAM3 preview map as an example run

### DIFF
--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "## Preview: model inputs and outputs\n",
     "\n",
-    "The interactive map linked below shows the input imagery and model output for this notebook's example AOI. Toggle layers in the sidebar to compare the input imagery with the model's PMTiles output side-by-side.\n",
+    "The interactive map linked below is an example run over Marion County, Oregon, showing the input imagery and model output at county scale. This notebook runs over a smaller AOI, College Park, Maryland, so your own output will cover a different area. Toggle layers in the sidebar to compare the input imagery with the model's PMTiles output side-by-side.\n",
     "\n",
     "**Layers:**\n",
     "- *SAM3 input mosaic*: RGB NAIP aerial imagery the model runs on\n",


### PR DESCRIPTION
Resolves [AI-453](https://linear.app/wherobots/issue/AI-453/sam3-notebooks-preview-section-calls-the-marion-county-run-this).

## Problem

The "Preview: model inputs and outputs" cell introduced its interactive map as:

> The interactive map linked below shows the input imagery and model output for **this notebook's example AOI**.

The linked map is the **Marion County, Oregon** run (`marion_county_optimized.zarr`, `marion_county_sam3.pmtiles`, link title `SAM3+Marion+County+OR`). The notebook's actual AOI, set in the next section, is **College Park, Maryland**:

```python
gdf = gpd.read_file(wkls.us.md.collegepark.geojson())
```

So the preview was not of this notebook's AOI — different state, and 3,085 km² versus 5.9 km². A reader running the notebook end to end got a College Park result with no way to compare it against what the preview had shown them.

## Change

One sentence in cell 2. Marion County is now named as an example run at county scale, and the notebook's own smaller AOI is stated explicitly:

> The interactive map linked below is an example run over Marion County, Oregon, showing the input imagery and model output at county scale. This notebook runs over a smaller AOI, College Park, Maryland, so your own output will cover a different area. Toggle layers in the sidebar to compare the input imagery with the model's PMTiles output side-by-side.

The map link is untouched — the county-scale run is useful as a "this scales" illustration, it just needed labelling as what it is. No new artifacts to host.

The wording also avoids implying the preview shares the notebook's date window, which it does not: Marion County's 30 cm NAIP is 2022 only, while College Park's is 2023, the year the notebook's `start_date`/`end_date` window uses. Verified against `s3://wherobots-examples/rasterflow/indexes/naip_index.parquet`.

## Why here and not in `wherobots/docs`

`tutorials/example-notebooks/rasterflow-sam3.mdx` is generated from this notebook by `convert-notebooks.yml`, and the docs README says manual edits there are overwritten on the next sync. The rendered page picks this up automatically.

## Noticed but not changed

The viz link in this same cell still carries `&l1.sl.swimming+pools.vis=0`, a sublayer visibility param for a prompt the notebook no longer uses — leftover from AI-436, which removed the swimming pool text references but not this parameter. Left alone here to keep this PR to one concern.

## Testing

`json.load` round-trips the notebook and cell count is unchanged at 23. The diff is a single line; execution counts and outputs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)