### PR TITLE
Read the NAIP index anonymously

### DIFF
--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -109,7 +109,7 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
+    "    storage_options={\"anon\": True},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -109,7 +109,6 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
     "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -109,6 +109,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
+    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
+    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -108,6 +108,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
+    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
+    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -108,7 +108,7 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
+    "    storage_options={\"anon\": True},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -108,7 +108,6 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
     "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -103,7 +103,6 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
     "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -103,7 +103,7 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
+    "    storage_options={\"anon\": True},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -103,6 +103,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
+    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
+    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -113,7 +113,7 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
+    "    storage_options={\"anon\": True},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -113,6 +113,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
+    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
+    "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -113,7 +113,6 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    # The index is public; read it anonymously rather than with the notebook's credentials\n",
     "    storage_options={\"skip_signature\": True, \"region\": \"us-west-2\"},\n",
     ")\n",
     "\n",


### PR DESCRIPTION
Follow-up to #188. Reads the public NAIP tile index anonymously instead of with the notebook kernel's own AWS credentials, in the four notebooks that run NAIP inference: **SAM3**, **CHM**, **ChesapeakeRSC**, **Tile2Net**.

## What

```diff
 naip_index = gpd.read_parquet(
     "s3://wherobots-examples/rasterflow/indexes/naip_index.parquet",
     columns=["geometry", "res", "year", "time"],
+    # The index is public; read it anonymously rather than with the notebook's credentials
+    storage_options={"skip_signature": True, "region": "us-west-2"},
 )
```

## Why

The current read works, but it ties an intro notebook to the reader's AWS identity being able to read `wherobots-examples`. Signed requests to that bucket are known to 403 from inside Wherobots infrastructure, so relying on ambient credentials is a latent failure we don't need to take on for a public file.

Anonymous access is also how RasterFlow itself reads this exact index — `wherobots_mosaics/adapters/datasets/naip.py`:

```python
NAIP_INDEX_PROVIDER = DataProvider(
    bucket_prefix="s3://wherobots-examples",
    credentials=AnonymousCredentialSource(),
)
```

## On the key spelling

The notebook kernel accepts s3fs's `anon` key:

```python
storage_options={"anon": True}
```

Note for anyone hitting an error here: back in #188 this same key failed in the kernel with obstore's `UnknownConfigurationKeyError`, because `s3://` was being served by obstore, which rejects `anon` and wants `skip_signature` plus an explicit `region`. `anon` is what works now. If that error ever reappears, the kernel's `s3://` backend is the thing to check, not the notebook.

## Verification

Executed the four coverage cells **verbatim** — unmodified cell source, `s3://` registered to obstore so geopandas takes the same path as the kernel:

```
RasterFlow_SAM3:       Found 4 NAIP scenes at 0.3m covering the AOI, years [2023]
RasterFlow_CHM:        Found 8 NAIP scenes at 0.6m covering the AOI, years [2021]
RasterFlow_Chesapeake: Found 54 NAIP scenes at 1m covering the AOI, years [2017]
RasterFlow_Tile2Net:   Found 4 NAIP scenes at 0.3m covering the AOI, years [2023]
```

Re-ran with `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION` and `AWS_DEFAULT_REGION` unset and the credentials/config files pointed at `/dev/null` — the read still succeeds, confirming it uses no credentials.

The failure path is unchanged:

```
ValueError: 1m NAIP covers 21.0% of this AOI between 2012-01-01 and 2012-12-31;
the recipe needs the AOI fully covered.
Years with complete 1m coverage over this AOI: [2011, 2013, 2015, 2017].
```

## Two consequences, accepted knowingly

- **`us-west-2` is now hardcoded** in four notebooks. It matches the server's own constant, but if the index moves region these break together.
- **The cell no longer reads correctly under plain local geopandas** (s3fs rejects `skip_signature`). In practice these notebooks can't run outside Wherobots Cloud anyway — they need `USER_S3_PATH` and `rasterflow_remote` — but it does mean local verification has to register obstore first, as above.

