### PR TITLE
fix: make anonymous NAIP reads independent of kernel import order

### DIFF
--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -98,6 +98,7 @@
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
+    "import s3fs\n",
     "\n",
     "# Date range for imagery to be used by the model\n",
     "start_date = datetime(2021, 1, 1)\n",
@@ -109,7 +110,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"anon\": True},\n",
+    "    # Use s3fs explicitly: other notebook imports can change fsspec's S3 backend.\n",
+    "    filesystem=s3fs.S3FileSystem(anon=True),\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -97,6 +97,7 @@
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
+    "import s3fs\n",
     "\n",
     "# Date range for imagery to be used by the model\n",
     "start_date = datetime(2017, 1, 1)\n",
@@ -108,7 +109,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"anon\": True},\n",
+    "    # Use s3fs explicitly: other notebook imports can change fsspec's S3 backend.\n",
+    "    filesystem=s3fs.S3FileSystem(anon=True),\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_SAM3.ipynb
+++ b/Analyzing_Data/RasterFlow_SAM3.ipynb
@@ -92,6 +92,7 @@
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
+    "import s3fs\n",
     "\n",
     "# Date range for imagery to be used by the model\n",
     "start_date = datetime(2023, 1, 1)\n",
@@ -103,7 +104,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"anon\": True},\n",
+    "    # Use s3fs explicitly: other notebook imports can change fsspec's S3 backend.\n",
+    "    filesystem=s3fs.S3FileSystem(anon=True),\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -102,6 +102,7 @@
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
+    "import s3fs\n",
     "\n",
     "# Date range for imagery to be used by the model\n",
     "start_date = datetime(2023, 1, 1)\n",
@@ -113,7 +114,8 @@
     "naip_index = gpd.read_parquet(\n",
     "    \"s3://wherobots-examples/rasterflow/indexes/naip_index.parquet\",\n",
     "    columns=[\"geometry\", \"res\", \"year\", \"time\"],\n",
-    "    storage_options={\"anon\": True},\n",
+    "    # Use s3fs explicitly: other notebook imports can change fsspec's S3 backend.\n",
+    "    filesystem=s3fs.S3FileSystem(anon=True),\n",
     ")\n",
     "\n",
     "# Scenes at the model's resolution touching the AOI, compared in the index's CRS\n",


### PR DESCRIPTION
## What/Why

Fix anonymous NAIP index reads in Chesapeake, CHM, SAM3, and Tile2Net when another notebook has already imported `RasterflowClient` in the same kernel. Flyte replaces fsspec's S3 backend with obstore, which rejects `storage_options={"anon": True}`; GeoPandas then masks that configuration error with `FileNotFoundError`.

Related to [AI-417](https://linear.app/wherobots/issue/AI-417/publish-rasterflow-sample-notebooks-when-public-preview-launches). Report: [shared-kernel failure](https://wherobots.slack.com/archives/C09JJKC80UC/p1789080257167639).

## How

Pass `filesystem=s3fs.S3FileSystem(anon=True)` explicitly in all four coverage cells, keeping anonymous access independent of the process-wide fsspec registry.

## Verified

- Confirmed locally that importing `RasterflowClient` switches the S3 implementation from s3fs to obstore (Flyte 2.0.11).
- Reproduced the original `UnknownConfigurationKeyError` and masking `FileNotFoundError` after registering obstore for S3.
- Read all 1,441,581 rows of the live NAIP index with the explicit filesystem after that registration.
- Validated notebook JSON, changed-cell Python syntax, `git diff --check`, and commit hooks (repository structure and nb-clean).
- Full Studio notebook execution has not been run.

---
Co-authored with Codex.
