### PR TITLE
Clustering notebooks: plot with matplotlib instead of GeoPandas

### DIFF
--- a/Analyzing_Data/Clustering_DBSCAN.ipynb
+++ b/Analyzing_Data/Clustering_DBSCAN.ipynb
@@ -127,7 +127,7 @@
    "metadata": {},
    "source": [
     "## Visualization\n",
-    "Finally, we'll visualize the clusters using geopandas. Some manipulations are made to the data to improve the clarity of the visualization."
+    "Finally, we'll visualize the clusters with `matplotlib`. `ST_X` and `ST_Y` pull the point coordinates out of the geometry column, and some manipulations are made to the data to improve the clarity of the visualization."
    ]
   },
   {
@@ -137,22 +137,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import geopandas as gpd\n",
-    "import pyspark.sql.types as t\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "pdf = (clusters_df\n",
-    "       .withColumn(\"isCore\", (f.col(\"isCore\").cast(t.IntegerType()) + 1) * 40)\n",
-    "       .withColumn(\"cluster\", f.hash(\"cluster\").cast(t.StringType()))\n",
+    "       .selectExpr(\"ST_X(geometry) AS x\", \"ST_Y(geometry) AS y\", \"cluster\", \"isCore\")\n",
     "       .toPandas()\n",
     "      )\n",
-    "gdf = gpd.GeoDataFrame(pdf, geometry=\"geometry\")\n",
     "\n",
-    "gdf.plot(\n",
-    "    figsize=(10, 8),\n",
-    "    column=\"cluster\",\n",
-    "    markersize=gdf['isCore'],\n",
-    "    edgecolor='lightgray',\n",
-    ")"
+    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "ax.scatter(\n",
+    "    pdf[\"x\"], pdf[\"y\"],\n",
+    "    # One color per cluster (outliers get their own)\n",
+    "    c=pdf[\"cluster\"].astype(\"category\").cat.codes, cmap=\"tab20\",\n",
+    "    # Core points are drawn twice as large as border points and outliers\n",
+    "    s=(pdf[\"isCore\"].astype(int) + 1) * 40,\n",
+    "    edgecolors=\"lightgray\",\n",
+    ")\n",
+    "ax.set_title(\"DBSCAN clusters\")\n",
+    "plt.show()\n"
    ]
   }
  ],

--- a/Analyzing_Data/Clustering_DBSCAN.ipynb
+++ b/Analyzing_Data/Clustering_DBSCAN.ipynb
@@ -104,7 +104,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pyspark.sql.functions as f\n",
     "from sedona.spark import *\n",
     "\n",
     "df = sedona.createDataFrame(feature_matrix).select(ST_MakePoint(\"_1\", \"_2\").alias(\"geometry\"))\n",

--- a/Analyzing_Data/Local_Outlier_Factor.ipynb
+++ b/Analyzing_Data/Local_Outlier_Factor.ipynb
@@ -98,7 +98,7 @@
    "metadata": {},
    "source": [
     "## Visualization\n",
-    "We visualize the results using geopandas. Some manipulations are made to the data to improve the clarity of the visualization."
+    "We visualize the results with `matplotlib`, pulling the point coordinates out of the geometry column with `ST_X` and `ST_Y`. Some manipulations are made to the data to improve the clarity of the visualization."
    ]
   },
   {
@@ -108,25 +108,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "pdf = (outliers_df\n",
     "       .withColumn(\"lof\", f.col(\"lof\") * 50)\n",
+    "       .selectExpr(\"ST_X(geometry) AS x\", \"ST_Y(geometry) AS y\", \"lof\")\n",
     "       .toPandas()\n",
     "      )\n",
-    "gdf = gpd.GeoDataFrame(pdf, geometry=\"geometry\")\n",
     "\n",
-    "ax = gdf.plot(\n",
-    "    figsize=(10, 8),\n",
-    "    markersize=gdf['lof'],\n",
-    "    edgecolor='r',\n",
-    "    facecolors=\"none\",\n",
-    ")\n",
-    "\n",
-    "gdf.plot(ax=ax, figsize=(10, 8), color=\"k\", markersize=1, legend=True)\n",
-    "\n",
-    "ax.set_title('LOF Scores')\n",
-    "ax.legend(['Outlier Scores', 'Data points'])"
+    "fig, ax = plt.subplots(figsize=(10, 8))\n",
+    "# Circle size scales with the LOF score, so outliers stand out\n",
+    "ax.scatter(pdf[\"x\"], pdf[\"y\"], s=pdf[\"lof\"], edgecolors=\"r\", facecolors=\"none\", label=\"Outlier Scores\")\n",
+    "ax.scatter(pdf[\"x\"], pdf[\"y\"], s=1, color=\"k\", label=\"Data points\")\n",
+    "ax.set_title(\"LOF Scores\")\n",
+    "ax.legend()\n",
+    "plt.show()\n"
    ]
   }
  ],


### PR DESCRIPTION
## Description

GeoPandas overlaps with what WherobotsDB does, so the example notebooks should not lean on it. This is the non-RasterFlow half of that cleanup, split out of #198 so it can be audited and merged on its own.

`Clustering_DBSCAN` and `Local_Outlier_Factor` only used GeoPandas to plot (`GeoDataFrame.plot`). They now scatter with `matplotlib` from `ST_X` / `ST_Y`, keeping the same colors, marker sizes, and legend.

The RasterFlow notebooks and the CI guard that forbids GeoPandas are in #198, stacked on this PR. The guard has to land last: with only this PR merged it still finds 20 GeoPandas uses across the ten `RasterFlow_*` notebooks, so putting it here would turn `main` red.

### Verification

Both notebooks were run in Wherobots Cloud production (2026-09-11, runtime `2.34.12`, `tiny`) as job runs generated from their code cells in order: the `%pip install scikit-learn` magic became an in-script pip install, and each `plt.show()` was captured as a PNG in the run log. Runs `cv9jd9vycaasnc` (Clustering_DBSCAN) and `ef0ycui8a8jjrj` (Local_Outlier_Factor) both completed with no errors. `dbscan(...)` / `local_outlier_factor(...)` produced the expected tables, and the rendered plots match the previous GeoPandas output: three DBSCAN clusters in distinct colors with core points drawn larger and outliers as small dots; LOF circles scaled by score over the data points, with the legend.

## Checklist

- [x] I have tested these changes in Wherobots Cloud
- [x] Notebooks follow the [style guide](../CONTRIBUTING.md#style-guide)

---

## For Release PRs (Wherobots Team Only)

- [x] I will create tags from `main` after merge (or tags are not needed for this PR)
