### PR TITLE
RasterFlow notebooks: show mosaic indexes with mosaic_index_df

### DIFF
--- a/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
+++ b/Analyzing_Data/RasterFlow_Bring_Your_Own_Model.ipynb
@@ -402,9 +402,15 @@
    "outputs": [],
    "source": [
     "import wkls\n",
+    "from sedona.spark import *\n",
+    "\n",
+    "# WherobotsDB session, used below to inspect RasterFlow's outputs\n",
+    "config = SedonaContext.builder().getOrCreate()\n",
+    "sedona = SedonaContext.create(config)\n",
     "\n",
     "# Generate a WKT geometry for Nashua, NH using Well-Known Locations (https://github.com/wherobots/wkls)\n",
-    "aoi = wkls.us.nh.nashua.wkt()\n"
+    "aoi = wkls.us.nh.nashua.wkt()\n",
+    "\n"
    ]
   },
   {
@@ -449,7 +455,9 @@
     "        nodata= 0.0,\n",
     ")\n",
     "mosaic_store = mosaic_index.first_row_mosaic\n",
-    "mosaic_index.mosaic_index_gdf\n",
+    "\n",
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "mosaic_index.mosaic_index_df.show(truncate=60)\n",
     "```"
    ]
   },
@@ -532,7 +540,8 @@
     "        **asdict(custom_inference_config)\n",
     ")\n",
     "\n",
-    "predict_mosaic_output.mosaic_index_gdf\n",
+    "# Inspect the prediction index (one row per output mosaic location)\n",
+    "predict_mosaic_output.mosaic_index_df.show(truncate=60)\n",
     "```"
    ]
   },

--- a/Analyzing_Data/RasterFlow_CHM.ipynb
+++ b/Analyzing_Data/RasterFlow_CHM.ipynb
@@ -224,7 +224,8 @@
     "    model_recipe = ModelRecipes.META_CHM_V1\n",
     ")\n",
     "\n",
-    "model_output_index.mosaic_index_gdf"
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "model_output_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
+++ b/Analyzing_Data/RasterFlow_ChangeDetection.ipynb
@@ -67,6 +67,11 @@
     "\n",
     "import shapely\n",
     "import wkls\n",
+    "from sedona.spark import *\n",
+    "\n",
+    "config = SedonaContext.builder().getOrCreate()\n",
+    "sedona = SedonaContext.create(config)\n",
+    "\n",
     "# Generate a WKT geometry for Haskell County, Kansas using Well-Known Locations (https://github.com/wherobots/wkls)\n",
     "aoi = wkls.us.ks.haskellcounty.wkt()\n",
     "\n",
@@ -134,7 +139,8 @@
     "    end=datetime(2025, 1, 1),\n",
     ")\n",
     "\n",
-    "mosaic_index.mosaic_index_gdf"
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "mosaic_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {
@@ -264,7 +270,8 @@
     "    xy_block_multiplier=1\n",
     ")\n",
     "\n",
-    "model_output_index.mosaic_index_gdf"
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "model_output_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {
@@ -422,18 +429,6 @@
    "source": [
     "## Save the vectorized results to the catalog\n",
     "We can store these vectorized outputs in the catalog by using WherobotsDB to persist the GeoParquet results."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e954fa1e-7441-45bb-96bd-2cb8f70aa3c7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sedona.spark import *\n",
-    "config = SedonaContext.builder().getOrCreate()\n",
-    "sedona = SedonaContext.create(config)"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Chesapeake.ipynb
+++ b/Analyzing_Data/RasterFlow_Chesapeake.ipynb
@@ -231,7 +231,8 @@
     "    model_recipe = ModelRecipes.CHESAPEAKE_RSC\n",
     ")\n",
     "\n",
-    "model_output_index.mosaic_index_gdf"
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "model_output_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_FTW.ipynb
+++ b/Analyzing_Data/RasterFlow_FTW.ipynb
@@ -85,6 +85,11 @@
     "\n",
     "import shapely\n",
     "import wkls\n",
+    "from sedona.spark import *\n",
+    "\n",
+    "config = SedonaContext.builder().getOrCreate()\n",
+    "sedona = SedonaContext.create(config)\n",
+    "\n",
     "# Generate a WKT geometry for Haskell County, Kansas using Well-Known Locations (https://github.com/wherobots/wkls)\n",
     "aoi = wkls.us.ks.haskellcounty.wkt()\n",
     "\n",
@@ -158,7 +163,8 @@
     "    model_recipe = ModelRecipes.FTW,\n",
     ")\n",
     "\n",
-    "model_output_index.mosaic_index_gdf"
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "model_output_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {
@@ -264,18 +270,6 @@
    "source": [
     "## Save the vectorized results to the catalog\n",
     "We can store these vectorized outputs in the catalog by using WherobotsDB to persist the GeoParquet results."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e954fa1e-7441-45bb-96bd-2cb8f70aa3c7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sedona.spark import *\n",
-    "config = SedonaContext.builder().getOrCreate()\n",
-    "sedona = SedonaContext.create(config)"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_NAIP_Mosaic.ipynb
@@ -52,7 +52,11 @@
     "import shapely\n",
     "import wkls\n",
     "from rasterflow_remote import RasterflowClient\n",
-    "from rasterflow_remote.data_models import DatasetEnum\n"
+    "from rasterflow_remote.data_models import DatasetEnum\n",
+    "from sedona.spark import *\n",
+    "\n",
+    "config = SedonaContext.builder().getOrCreate()\n",
+    "sedona = SedonaContext.create(config)\n"
    ]
   },
   {
@@ -167,7 +171,7 @@
     ")\n",
     "\n",
     "# Inspect the mosaic index (one row per output mosaic location)\n",
-    "mosaic_index.mosaic_index_gdf"
+    "mosaic_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
+++ b/Analyzing_Data/RasterFlow_S2_Mosaic.ipynb
@@ -52,7 +52,11 @@
     "import wkls\n",
     "import xarray as xr\n",
     "from rasterflow_remote import RasterflowClient\n",
-    "from rasterflow_remote.data_models import DatasetEnum\n"
+    "from rasterflow_remote.data_models import DatasetEnum\n",
+    "from sedona.spark import *\n",
+    "\n",
+    "config = SedonaContext.builder().getOrCreate()\n",
+    "sedona = SedonaContext.create(config)\n"
    ]
   },
   {
@@ -142,7 +146,8 @@
     "    target_crs=3857,\n",
     ")\n",
     "\n",
-    "mosaic_index.mosaic_index_gdf"
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "mosaic_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {

--- a/Analyzing_Data/RasterFlow_Tile2Net.ipynb
+++ b/Analyzing_Data/RasterFlow_Tile2Net.ipynb
@@ -234,7 +234,8 @@
     "    model_recipe = ModelRecipes.TILE_2_NET,\n",
     ")\n",
     "\n",
-    "model_output_index.mosaic_index_gdf"
+    "# Inspect the mosaic index (one row per output mosaic location)\n",
+    "model_output_index.mosaic_index_df.show(truncate=60)"
    ]
   },
   {


### PR DESCRIPTION
## Description

Stacked on #198. Every RasterFlow notebook now shows its mosaic index with `MosaicResult.mosaic_index_df` (a WherobotsDB DataFrame read through the active Sedona session, added in wherobots/wherobots-rasterflow-remote#193) instead of displaying the GeoPandas-backed `mosaic_index_gdf`:

```python
mosaic_index = rf_client.build_mosaics(...)
mosaic_index.mosaic_index_df.show(truncate=60)
```

Eight code cells across the `RasterFlow_*` notebooks, plus the two markdown snippets in `Bring_Your_Own_Model`. Notebooks that only created their Sedona context late (in the "save to catalog" section) now create it up front, since the first index display needs an active session.

## Checklist

- [ ] I have tested these changes in Wherobots Cloud
- [x] Notebooks follow the [style guide](../CONTRIBUTING.md#style-guide)

---

## For Release PRs (Wherobots Team Only)

- [x] I will create tags from `main` after merge (or tags are not needed for this PR)
